### PR TITLE
Add support for receiving shared images from other apps

### DIFF
--- a/PixelsorterApp/MainPage.xaml.cs
+++ b/PixelsorterApp/MainPage.xaml.cs
@@ -97,31 +97,55 @@ namespace PixelsorterApp
             UpdateWhatToSortStateLabel();
         }
 
+        protected override void OnAppearing()
+        {
+            base.OnAppearing();
+            SharedImageBridge.SharedImageReceived += OnSharedImageReceived;
+
+            if (SharedImageBridge.TryConsumePendingImagePath(out var pendingImagePath) && pendingImagePath is not null)
+            {
+                LoadImageFromPath(pendingImagePath);
+            }
+        }
+
+        protected override void OnDisappearing()
+        {
+            SharedImageBridge.SharedImageReceived -= OnSharedImageReceived;
+            base.OnDisappearing();
+        }
+
+        private void OnSharedImageReceived(string sharedImagePath)
+        {
+            LoadImageFromPath(sharedImagePath);
+        }
+
+        private void LoadImageFromPath(string path)
+        {
+            this.imagePath = path;
+            this.imgSource = ImageSource.FromFile(path);
+
+            MainThread.BeginInvokeOnMainThread(() =>
+            {
+                LoadImageBtn.HeightRequest = -1;
+                LoadImageBtn.MaximumHeightRequest = double.PositiveInfinity;
+                LoadImageBtn.Source = this.imgSource;
+                sortBtn.IsEnabled = true;
+                saveBtn.IsVisible = false;
+            });
+        }
+
 
 
 
         private async void LoadImage_Clicked(object sender, EventArgs e)
         {
-
-            saveBtn.IsVisible = false; // Hide the save button when loading a new image
             var results = await MediaPicker.PickPhotosAsync();
 
             foreach (var file in results)
             {
-                this.imagePath = file.FullPath; // Store the file path
-
-                // Directly assign the file source for display
-                this.imgSource = ImageSource.FromFile(this.imagePath);
+                LoadImageFromPath(file.FullPath);
                 break;
             }
-
-            MainThread.BeginInvokeOnMainThread(() =>
-            {
-                LoadImageBtn.HeightRequest = -1; // remove fixed height request so it resizes based on constraints
-                LoadImageBtn.MaximumHeightRequest = double.PositiveInfinity; // allow full aspect-ratio expansion
-                LoadImageBtn.Source = this.imgSource;
-                sortBtn.IsEnabled = true; // Enable the sort button now that an image is loaded
-            });
         }
 
         private string? sortedImagePath; // Path to the temporarily saved sorted image

--- a/PixelsorterApp/Platforms/Android/MainActivity.cs
+++ b/PixelsorterApp/Platforms/Android/MainActivity.cs
@@ -1,11 +1,78 @@
 ﻿using Android.App;
 using Android.Content.PM;
 using Android.OS;
+using Android.Webkit;
 
 namespace PixelsorterApp
 {
     [Activity(Theme = "@style/Maui.SplashTheme", MainLauncher = true, LaunchMode = LaunchMode.SingleTop, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.UiMode | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.Density)]
+    [IntentFilter([Android.Content.Intent.ActionSend],
+              Categories = new[] { Android.Content.Intent.CategoryDefault },
+              DataMimeType = "image/*")]
     public class MainActivity : MauiAppCompatActivity
     {
+        /// <summary>
+        /// Initializes the activity and processes the incoming intent when the activity is created.
+        /// </summary>
+        /// <remarks>Overrides the base implementation to perform additional setup specific to this
+        /// activity. Always calls the base method to ensure proper initialization.</remarks>
+        /// <param name="savedInstanceState">An optional bundle containing the activity's previously saved state, or null if no state was saved.</param>
+        protected override void OnCreate(Bundle? savedInstanceState)
+        {
+            base.OnCreate(savedInstanceState);
+            HandleIntent(Intent);
+        }
+
+        /// <summary>
+        /// Handles a new intent delivered to the activity while it is running.
+        /// </summary>
+        /// <remarks>This method is called when the activity receives a new intent via an existing
+        /// instance, such as when launched with the singleTop launch mode. It is important to call the base
+        /// implementation to ensure the intent is properly handled by the Android framework.</remarks>
+        /// <param name="intent">The intent containing the new data to be processed. This parameter can be null if no intent is provided.</param>
+        protected override void OnNewIntent(Android.Content.Intent? intent)
+        {
+            base.OnNewIntent(intent);
+            HandleIntent(intent);
+        }
+
+        /// <summary>
+        /// Processes an incoming intent to handle images shared from other applications.
+        /// </summary>
+        /// <remarks>If the intent contains a valid image, the method retrieves its URI and saves a copy
+        /// to the application's cache directory. The path to the cached image is then made available to the
+        /// application. Ensure that the intent's type is supported and that the image can be accessed by the
+        /// application.</remarks>
+        /// <param name="intent">The intent containing the shared image data. This parameter must not be null and should have an action of
+        /// <see cref="Android.Content.Intent.ActionSend"/> with a MIME type that starts with "image/".</param>
+        private void HandleIntent(Android.Content.Intent? intent)
+        {
+            if (intent?.Action == Android.Content.Intent.ActionSend && intent.Type != null)
+            {
+                if (intent.Type.StartsWith("image/"))
+                {
+                    // Get the URI of the shared image
+                    if (intent.GetParcelableExtra(Android.Content.Intent.ExtraStream, Java.Lang.Class.FromType(typeof(Android.Net.Uri))) is Android.Net.Uri imageUri)
+                    {
+                        var extension = MimeTypeMap.Singleton?.GetExtensionFromMimeType(intent.Type);
+                        var cacheFileName = string.IsNullOrWhiteSpace(extension)
+                            ? $"shared_{Guid.NewGuid()}"
+                            : $"shared_{Guid.NewGuid()}.{extension}";
+                        var cachePath = Path.Combine(FileSystem.CacheDirectory, cacheFileName);
+
+                        using var input = ContentResolver?.OpenInputStream(imageUri);
+                        if (input is null)
+                        {
+                            return;
+                        }
+
+                        using var output = File.Create(cachePath);
+                        input.CopyTo(output);
+
+                        MainThread.BeginInvokeOnMainThread(() => SharedImageBridge.SetSharedImagePath(cachePath));
+                    }
+                }
+            }
+        }
     }
 }

--- a/PixelsorterApp/SharedImageBridge.cs
+++ b/PixelsorterApp/SharedImageBridge.cs
@@ -1,0 +1,54 @@
+namespace PixelsorterApp
+{
+    /// <summary>
+    /// Provides a thread-safe mechanism for sharing and consuming image paths between different components of an
+    /// application.
+    /// </summary>
+    /// <remarks>This static class enables components to set a shared image path and allows other components
+    /// to consume it in a synchronized manner. The SharedImageReceived event is raised whenever a new image path is
+    /// set, enabling subscribers to react to image sharing events. All access to the shared image path is synchronized
+    /// to ensure thread safety.</remarks>
+    public static class SharedImageBridge
+    {
+        private static readonly object SyncRoot = new();
+        private static string? pendingImagePath;
+
+        public static event Action<string>? SharedImageReceived;
+
+        /// <summary>
+        /// Sets the path of the shared image and notifies subscribers of the updated path.
+        /// </summary>
+        /// <remarks>This method is thread-safe. It raises the SharedImageReceived event after updating
+        /// the shared image path, allowing subscribers to respond to the change.</remarks>
+        /// <param name="imagePath">The file system path to the image to be shared. This value must not be null or empty.</param>
+        public static void SetSharedImagePath(string imagePath)
+        {
+            lock (SyncRoot)
+            {
+                pendingImagePath = imagePath;
+            }
+
+            SharedImageReceived?.Invoke(imagePath);
+        }
+
+        /// <summary>
+        /// Attempts to retrieve and clear the pending image path in a thread-safe manner.
+        /// </summary>
+        /// <remarks>This method is thread-safe. If no pending image path is available, the <paramref
+        /// name="imagePath"/> parameter is set to <see langword="null"/>.</remarks>
+        /// <param name="imagePath">When this method returns, contains the pending image path if one was available; otherwise, <see
+        /// langword="null"/>.</param>
+        /// <returns><see langword="true"/> if a pending image path was successfully retrieved; otherwise, <see
+        /// langword="false"/>.</returns>
+        public static bool TryConsumePendingImagePath(out string? imagePath)
+        {
+            lock (SyncRoot)
+            {
+                imagePath = pendingImagePath;
+                pendingImagePath = null;
+            }
+
+            return !string.IsNullOrWhiteSpace(imagePath);
+        }
+    }
+}


### PR DESCRIPTION
Enable PixelsorterApp to handle images shared via Android's "Share" menu by adding an intent filter and processing shared image intents in MainActivity. Introduce SharedImageBridge for thread-safe image path sharing and event notification. Update MainPage to load shared images on receipt or app resume, and refactor image loading logic for reuse. This improves interoperability and user experience.