### PR TITLE
Add network check before enabling masking feature

### DIFF
--- a/PixelsorterApp/MainPage.xaml.cs
+++ b/PixelsorterApp/MainPage.xaml.cs
@@ -23,7 +23,7 @@ namespace PixelsorterApp
         private bool useInvertedMask = false;
         private NDArray? mask = null;
         private NDArray? invertedMask = null;
-        
+
 
         private void InitializeSortDirectionOptions()
         {
@@ -250,6 +250,11 @@ namespace PixelsorterApp
 
         private async void useMasking_Toggled(object sender, ToggledEventArgs e)
         {
+            if (e.Value && !checkNetworkAcces())
+            {
+                useMasking.IsToggled = false;
+                return;
+            }
             bool maskingLicenseAccepted = Preferences.Get("MaskingLicenseAccepted", false);
             if (!maskingLicenseAccepted && e.Value)
             {
@@ -260,7 +265,7 @@ namespace PixelsorterApp
                     "Don't accept"
                     );
                 Preferences.Set("MaskingLicenseAccepted", response);
-                
+
                 if (!response)
                 {
                     useMasking.IsToggled = false;
@@ -271,6 +276,23 @@ namespace PixelsorterApp
             this.useMask = e.Value;
             maskPadding.IsVisible = e.Value;
             UpdateSortDirectionPicker();
+        }
+
+        private bool checkNetworkAcces()
+        {
+            NetworkAccess accessType = Connectivity.Current.NetworkAccess;
+
+            if (Preferences.Get("MaskingLicenseAccepted", false))
+            {
+                return true;
+            }
+
+            if (accessType != NetworkAccess.Internet)
+            {
+                _ = DisplayAlertAsync("No Internet Connection", "An internet connection is required to use the masking feature. Please connect to the internet and try again.", "OK");
+                return false;
+            }
+            return true;
         }
 
         private void sortBy_SelectedIndexChanged(object sender, EventArgs e)

--- a/PixelsorterApp/Platforms/Android/MainApplication.cs
+++ b/PixelsorterApp/Platforms/Android/MainApplication.cs
@@ -4,6 +4,7 @@ using Android.Runtime;
 [assembly: UsesPermission(Android.Manifest.Permission.ReadMediaAudio)]
 [assembly: UsesPermission(Android.Manifest.Permission.ReadMediaImages)]
 [assembly: UsesPermission(Android.Manifest.Permission.ReadMediaVideo)]
+[assembly: UsesPermission(Android.Manifest.Permission.AccessNetworkState)]
 namespace PixelsorterApp
 {
     [Application]


### PR DESCRIPTION
## Description
Added a network connectivity check to ensure users can only enable the masking feature when an internet connection is available, unless the masking license has already been accepted. Introduced checkNetworkAcces() in MainPage.xaml.cs and updated useMasking_Toggled to use this check. Also added ACCESS_NETWORK_STATE permission in MainApplication.cs for Android support.

## Related Issue
Issue #5 

## 🍎 Apple Platform Testing
<!-- IMPORTANT: The maintainer DOES NOT own an Apple device. If your changes affect iOS or MacCatalyst, you MUST test them yourself and provide proof of functionality. -->
- [ ] My changes do NOT affect iOS or MacCatalyst.
- [ ] My changes affect iOS/MacCatalyst, and I have tested them thoroughly on a device/simulator. 
<!-- If you checked the second box, please attach screenshots, screen recordings, or describe your testing process below: -->


## Checklist:
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have built the solution and verified that it complies successfully.
- [x] I have tested my changes on Windows and/or Android (or they are platform-agnostic).
- [x] I have adhered to the existing UI styling (e.g., flat layouts, non-editable looking pickers, visually distinct disabled buttons).
- [x] My changes generate no new warnings.
