### PR TITLE
Improve image preview sizing and add border on desktop

### DIFF
--- a/PixelsorterApp/MainPage.xaml
+++ b/PixelsorterApp/MainPage.xaml
@@ -77,6 +77,7 @@
             </Grid>
 
             <Border
+                x:Name="imagePreviewBorder"
                 Stroke="{AppThemeBinding Light=#E0E0E0, Dark=#303030}"
                 StrokeThickness="1"
                 BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1E1E1E}"
@@ -87,7 +88,6 @@
                         x:Name="LoadImageBtn"
                         Source="uploadplaceholder.png"
                         Aspect="AspectFit"
-                        MaximumHeightRequest="300"
                         HeightRequest="130">
                         <Image.GestureRecognizers>
                             <TapGestureRecognizer Tapped="LoadImage_Clicked" />

--- a/PixelsorterApp/MainPage.xaml.cs
+++ b/PixelsorterApp/MainPage.xaml.cs
@@ -23,6 +23,7 @@ namespace PixelsorterApp
         private bool useInvertedMask = false;
         private NDArray? mask = null;
         private NDArray? invertedMask = null;
+        private readonly double DESKTOP_IMAGE_HEIGHT = 0.75;
 
 
         private void InitializeSortDirectionOptions()
@@ -73,6 +74,8 @@ namespace PixelsorterApp
         {
             InitializeComponent();
 
+            SizeChanged += (_, _) => ApplyImageSizeForCurrentDevice();
+
             sortBtn.IsVisible = true;
             sortBtn.IsEnabled = false; // Disable the sort button until an image is loaded
 
@@ -98,6 +101,7 @@ namespace PixelsorterApp
             sortingCriterion = sortByOptionNames.Length > 0 ? sortByOptions[sortByOptionNames[0]] : null;
             sortingDirection = sortDirectionOptionNames.Length > 0 ? sortDirectionOptions[sortDirectionOptionNames[0]] : SortDirections.RowRightToLeft;
             UpdateWhatToSortStateLabel();
+            ApplyImageSizeForCurrentDevice();
         }
 
         protected override void OnAppearing()
@@ -131,11 +135,26 @@ namespace PixelsorterApp
             MainThread.BeginInvokeOnMainThread(() =>
             {
                 LoadImageBtn.HeightRequest = -1;
-                LoadImageBtn.MaximumHeightRequest = double.PositiveInfinity;
+                ApplyImageSizeForCurrentDevice();
                 LoadImageBtn.Source = this.imgSource;
                 sortBtn.IsEnabled = true;
                 saveBtn.IsVisible = false;
             });
+        }
+
+        private void ApplyImageSizeForCurrentDevice()
+        {
+            if (DeviceInfo.Idiom == DeviceIdiom.Desktop)
+            {
+                imagePreviewBorder.MaximumHeightRequest = this.Height > 0
+                    ? this.Height * DESKTOP_IMAGE_HEIGHT
+                    : double.PositiveInfinity;
+                LoadImageBtn.MaximumHeightRequest = double.PositiveInfinity;
+                return;
+            }
+
+            imagePreviewBorder.MaximumHeightRequest = double.PositiveInfinity;
+            LoadImageBtn.MaximumHeightRequest = double.PositiveInfinity;
         }
 
         private void UseLoadingOverlay(String text)


### PR DESCRIPTION
## Description
Add a themed border around the image preview area and implement dynamic sizing: on desktop devices, the preview is limited to 75% of the window height, while on other devices it remains unrestricted. This replaces previous static sizing and ensures a better user experience across platforms.

## Related Issue
None

## 🍎 Apple Platform Testing
<!-- IMPORTANT: The maintainer DOES NOT own an Apple device. If your changes affect iOS or MacCatalyst, you MUST test them yourself and provide proof of functionality. -->
- [x] My changes do NOT affect iOS or MacCatalyst.
- [ ] My changes affect iOS/MacCatalyst, and I have tested them thoroughly on a device/simulator. 
<!-- If you checked the second box, please attach screenshots, screen recordings, or describe your testing process below: -->


## Checklist:
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have built the solution and verified that it complies successfully.
- [x] I have tested my changes on Windows and/or Android (or they are platform-agnostic).
- [x] I have adhered to the existing UI styling (e.g., flat layouts, non-editable looking pickers, visually distinct disabled buttons).
- [x] My changes generate no new warnings.
