### PR TITLE
Refactor "What to sort" UI: Switch to RadioButtons

### DIFF
--- a/PixelsorterApp/MainPage.xaml
+++ b/PixelsorterApp/MainPage.xaml
@@ -246,11 +246,13 @@
                                 x:Name="sortBackgroundRadio"
                                 Content="Background"
                                 IsChecked="True"
-                                CheckedChanged="whatToSort_Toggled" />
+                                CheckedChanged="whatToSort_CheckedChanged"
+                                SemanticProperties.Description="Select to sort pixels based on the background area" />
                             <RadioButton
                                 x:Name="sortForegroundRadio"
                                 Content="Foreground"
-                                CheckedChanged="whatToSort_Toggled" />
+                                CheckedChanged="whatToSort_CheckedChanged"
+                                SemanticProperties.Description="Select to sort pixels based on the foreground area" />
                         </HorizontalStackLayout>
                     </Grid>
                 </VerticalStackLayout>

--- a/PixelsorterApp/MainPage.xaml.cs
+++ b/PixelsorterApp/MainPage.xaml.cs
@@ -387,7 +387,7 @@ namespace PixelsorterApp
             }
         }
 
-        private void whatToSort_Toggled(object sender, CheckedChangedEventArgs e)
+        private void whatToSort_CheckedChanged(object sender, CheckedChangedEventArgs e)
         {
             if (sender == sortBackgroundRadio && e.Value)
             {


### PR DESCRIPTION
## Description
Replaced the Switch and state label for selecting "What to sort" with horizontally arranged RadioButtons for "Background" and "Foreground". Updated event handling to use CheckedChanged from the RadioButtons, and removed the now-unnecessary state label and related code. This improves clarity and makes the selection more explicit in the UI.

## Related Issue
#7 

## 🍎 Apple Platform Testing
<!-- IMPORTANT: The maintainer DOES NOT own an Apple device. If your changes affect iOS or MacCatalyst, you MUST test them yourself and provide proof of functionality. -->
- [x] My changes do NOT affect iOS or MacCatalyst.
- [ ] My changes affect iOS/MacCatalyst, and I have tested them thoroughly on a device/simulator. 
<!-- If you checked the second box, please attach screenshots, screen recordings, or describe your testing process below: -->


## Checklist:
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have built the solution and verified that it complies successfully.
- [x] I have tested my changes on Windows and/or Android (or they are platform-agnostic).
- [x] I have adhered to the existing UI styling (e.g., flat layouts, non-editable looking pickers, visually distinct disabled buttons).
- [x] My changes generate no new warnings.
<img width="540" height="1147" alt="image dark mode" src="https://github.com/user-attachments/assets/063d75b5-4359-4e6e-b492-d102095e0455" />
<img width="540" height="1147" alt="image white mode" src="https://github.com/user-attachments/assets/71a17855-05e3-4c10-9322-738285361567" />