### PR TITLE
Refine model download trigger and async handling

### DIFF
--- a/PixelsorterApp/MainPage.xaml.cs
+++ b/PixelsorterApp/MainPage.xaml.cs
@@ -437,6 +437,7 @@ namespace PixelsorterApp
             if (!masker.IsModelDownloaded && netAccess && e.Value)
             {
                 UseLoadingOverlay("Downloading...");
+                sortBtn.IsEnabled = false;
                 try
                 {
                     await masker.DownloadModel();
@@ -454,6 +455,7 @@ namespace PixelsorterApp
                 {
                     loadingIndicator.IsRunning = false;
                     loadingOverlay.IsVisible = false;
+                    sortBtn.IsEnabled = true;
                 }
             }
 


### PR DESCRIPTION
## Description
Only trigger model download when toggling on and conditions are met, preventing unnecessary downloads and fixing the bug that the model gets downloaded after declining the license. Simplify async logic by directly awaiting masker.DownloadModel() instead of using Task.Run ensuring that the download animation continues until the download is complete.

## Related Issue
Fixes #17, #15 

## 🍎 Apple Platform Testing
<!-- IMPORTANT: The maintainer DOES NOT own an Apple device. If your changes affect iOS or MacCatalyst, you MUST test them yourself and provide proof of functionality. -->
- [x] My changes do NOT affect iOS or MacCatalyst.
- [ ] My changes affect iOS/MacCatalyst, and I have tested them thoroughly on a device/simulator. 
<!-- If you checked the second box, please attach screenshots, screen recordings, or describe your testing process below: -->


## Checklist:
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have built the solution and verified that it complies successfully.
- [x] I have tested my changes on Windows and/or Android (or they are platform-agnostic).
- [x] I have adhered to the existing UI styling (e.g., flat layouts, non-editable looking pickers, visually distinct disabled buttons).
- [x] My changes generate no new warnings.
