### PR TITLE
Switch sorting criteria from RGBA to HSL color space

### DIFF
--- a/PixelsorterApp/MainPage.xaml.cs
+++ b/PixelsorterApp/MainPage.xaml.cs
@@ -2,6 +2,7 @@
 using PixelsorterClassLib.Core;
 using PixelsorterClassLib.Masks;
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.ColorSpaces;
 using SixLabors.ImageSharp.PixelFormats;
 using UraniumUI.Material.Controls;
 using Image = PixelsorterClassLib.Core.Image;
@@ -16,9 +17,9 @@ namespace PixelsorterApp
         private readonly CannyMask cannyMasker = new();
         private bool useSubjectMask = false;
         private bool useCanny = false;
-        private readonly Dictionary<string, Func<Rgba32, float>> sortByOptions = SortBy.GetAllSortingCriteria();
+        private readonly Dictionary<string, Func<Hsl, float>> sortByOptions = SortBy.GetAllSortingCriteria();
         private readonly Dictionary<string, SortDirections> sortDirectionOptions = [];
-        private Func<Rgba32, float>? sortingCriterion;
+        private Func<Hsl, float>? sortingCriterion;
         private SortDirections sortingDirection;
         private readonly string[] sortByOptionNames;
         private string[] sortDirectionOptionNames;


### PR DESCRIPTION
## Description
Updated sorting logic to use HSL instead of RGBA, changing relevant function types and dictionaries. This enables more perceptually relevant pixel sorting based on hue, saturation, and lightness.

## Related Issue
https://github.com/h43lb1t0/PixelsorterClassLib/pull/12

## 🍎 Apple Platform Testing
<!-- IMPORTANT: The maintainer DOES NOT own an Apple device. If your changes affect iOS or MacCatalyst, you MUST test them yourself and provide proof of functionality. -->
- [x] My changes do NOT affect iOS or MacCatalyst.
- [ ] My changes affect iOS/MacCatalyst, and I have tested them thoroughly on a device/simulator. 
<!-- If you checked the second box, please attach screenshots, screen recordings, or describe your testing process below: -->


## Checklist:
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have built the solution and verified that it complies successfully.
- [x] I have tested my changes on Windows and/or Android (or they are platform-agnostic).
- [x] I have adhered to the existing UI styling (e.g., flat layouts, non-editable looking pickers, visually distinct disabled buttons).
- [x] My changes generate no new warnings.
