### PR TITLE
Adjusted mask creation to use new MaskOptions to addapt to the classL…

### DIFF
--- a/PixelsorterApp/MainPage.xaml
+++ b/PixelsorterApp/MainPage.xaml
@@ -26,426 +26,446 @@
         <ScrollView Grid.Row="0">
             <VerticalStackLayout Padding="20,20,20,30" Spacing="16">
 
-            <!--  Headder  -->
-            <Grid
-                ColumnDefinitions="*,Auto"
-                ColumnSpacing="8"
-                RowDefinitions="Auto,Auto">
-                <Label
-                    Grid.Row="0"
-                    Grid.Column="0"
-                    FontAttributes="Bold"
-                    FontSize="28"
-                    SemanticProperties.HeadingLevel="Level1"
-                    Text="Pixel Sorter" />
-                <Label
-                    Grid.Row="1"
-                    Grid.Column="0"
-                    FontSize="14"
-                    Opacity="0.8"
-                    Text="Load an image, choose options, and sort." />
-                <Button
-                    Grid.Row="0"
-                    Grid.RowSpan="2"
-                    Grid.Column="1"
-                    Padding="0"
-                    BackgroundColor="Transparent"
-                    Clicked="HelpMenuBtn_Clicked"
-                    CornerRadius="18"
-                    FontSize="22"
-                    HeightRequest="36"
-                    SemanticProperties.Description="Open additional app options"
-                    SemanticProperties.Hint="Opens help options including licenses and privacy policy"
-                    Text="⋮"
-                    TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight},
-                                                Dark={StaticResource TextSecondaryDark}}"
-                    WidthRequest="36" />
-            </Grid>
-
-            <!--  Image box  -->
-            <Border
-                x:Name="imagePreviewBorder"
-                Padding="12"
-                BackgroundColor="{AppThemeBinding Light={StaticResource SurfaceLight},
-                                                  Dark={StaticResource SurfaceDark}}"
-                Stroke="{AppThemeBinding Light={StaticResource DividerLight},
-                                         Dark={StaticResource DividerDark}}"
-                StrokeShape="RoundRectangle 16"
-                StrokeThickness="1"
-                StyleClass="Elevation3">
-                <Border.Shadow>
-                    <Shadow Brush="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" Offset="0,3" Radius="12" Opacity="0.08" />
-                </Border.Shadow>
-                <Grid RowDefinitions="Auto,Auto">
-                    <local:ImageViewer
-                        x:Name="imageViewer"
-                        Grid.Row="0"
-                        HeightRequest="130"
-                        ImageTapped="LoadImage_Clicked"
-                        SemanticProperties.Description="Image viewer"
-                        StyleClass="Elevation5" />
-                    <Grid
-                        x:Name="loadingOverlay"
-                        Grid.Row="0"
-                        BackgroundColor="#80000000"
-                        InputTransparent="False"
-                        IsVisible="False"
-                        SemanticProperties.Description="Busy">
-                        <VerticalStackLayout
-                            HorizontalOptions="Center"
-                            Spacing="10"
-                            VerticalOptions="Center">
-                            <ActivityIndicator
-                                x:Name="loadingIndicator"
-                                HeightRequest="40"
-                                IsRunning="False"
-                                WidthRequest="40"
-                                Color="{StaticResource White}" />
-                            <Label
-                                x:Name="loadingOverlayLabel"
-                                FontAttributes="Bold"
-                                HorizontalTextAlignment="Center"
-                                Text=""
-                                TextColor="{StaticResource White}" />
-                        </VerticalStackLayout>
-                    </Grid>
+                <!--  Headder  -->
+                <Grid
+                    ColumnDefinitions="*,Auto"
+                    ColumnSpacing="8"
+                    RowDefinitions="Auto,Auto">
                     <Label
-                        x:Name="whatIsThisLabel"
+                        Grid.Row="0"
+                        Grid.Column="0"
+                        FontAttributes="Bold"
+                        FontSize="28"
+                        SemanticProperties.HeadingLevel="Level1"
+                        Text="Pixel Sorter" />
+                    <Label
                         Grid.Row="1"
-                        Margin="0,8,0,0"
-                        FontSize="12"
-                        HorizontalOptions="Center"
-                        SemanticProperties.Description="Current image caption"
-                        Text="Tap to load an image"
+                        Grid.Column="0"
+                        FontSize="14"
+                        Opacity="0.8"
+                        Text="Load an image, choose options, and sort." />
+                    <Button
+                        Grid.Row="0"
+                        Grid.RowSpan="2"
+                        Grid.Column="1"
+                        Padding="0"
+                        BackgroundColor="Transparent"
+                        Clicked="HelpMenuBtn_Clicked"
+                        CornerRadius="18"
+                        FontSize="22"
+                        HeightRequest="36"
+                        SemanticProperties.Description="Open additional app options"
+                        SemanticProperties.Hint="Opens help options including licenses and privacy policy"
+                        Text="⋮"
                         TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight},
                                                     Dark={StaticResource TextSecondaryDark}}"
-                        VerticalOptions="Center" />
+                        WidthRequest="36" />
                 </Grid>
-            </Border>
 
-            <Label
-                Margin="4,10,4,4"
-                FontAttributes="Bold"
-                FontSize="13"
-                SemanticProperties.HeadingLevel="Level2"
-                Text="SORT SETTINGS"
-                TextColor="{AppThemeBinding Light={StaticResource Primary},
-                                            Dark={StaticResource PrimaryDark}}" />
-
-            <Border
-                Padding="0"
-                BackgroundColor="{AppThemeBinding Light={StaticResource SurfaceLight},
-                                                  Dark={StaticResource SurfaceDark}}"
-                StrokeShape="RoundRectangle 12"
-                Stroke="{AppThemeBinding Light={StaticResource DividerLight},
-                                         Dark={StaticResource DividerDark}}"
-                StrokeThickness="1"
-                StyleClass="Elevation3">
-                <Border.Shadow>
-                    <Shadow Brush="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" Offset="0,3" Radius="10" Opacity="0.10" />
-                </Border.Shadow>
-                <VerticalStackLayout Spacing="0">
-                    <VerticalStackLayout Padding="16,16,16,8" Spacing="16">
-                        <material:PickerField
-                            x:Name="sortBy"
-                            Title="Sort by"
-                            AccentColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
-                            AllowClear="False"
-                            SemanticProperties.Description="A dropdown menu to select what to sort the Pixels by"
-                            TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}" />
-                        <material:PickerField
-                            x:Name="sortDirection"
-                            Title="Direction"
-                            AccentColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
-                            AllowClear="False"
-                            SemanticProperties.Description="A dropdown to select in what direction to sort the pixels"
-                            TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}" />
-                    </VerticalStackLayout>
-                </VerticalStackLayout>
-            </Border>
-
-            <Label
-                Margin="4,10,4,4"
-                FontAttributes="Bold"
-                FontSize="13"
-                SemanticProperties.HeadingLevel="Level2"
-                Text="MASKING OPTIONS"
-                TextColor="{AppThemeBinding Light={StaticResource Primary},
-                                            Dark={StaticResource PrimaryDark}}" />
-
-            <Border
-                Padding="0"
-                BackgroundColor="{AppThemeBinding Light={StaticResource SurfaceLight},
-                                                  Dark={StaticResource SurfaceDark}}"
-                StrokeShape="RoundRectangle 12"
-                Stroke="{AppThemeBinding Light={StaticResource DividerLight},
-                                         Dark={StaticResource DividerDark}}"
-                StrokeThickness="1"
-                StyleClass="Elevation3">
-                <Border.Shadow>
-                    <Shadow Brush="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" Offset="0,3" Radius="10" Opacity="0.10" />
-                </Border.Shadow>
-                <VerticalStackLayout Spacing="0">
-                    <Grid Padding="16,10" ColumnDefinitions="*,Auto">
-                        <Label
-                            FontSize="16"
-                            Text="Use Canny masking"
-                            VerticalOptions="Center" />
-                        <Switch
-                            x:Name="useCannySwitch"
-                            Grid.Column="1"
-                            OnColor="{AppThemeBinding Light={StaticResource Secondary},
-                                                      Dark={StaticResource SecondaryDarkText}}"
-                            SemanticProperties.Description="Toggle switch to turn masking with Canny on or off"
-                            SemanticProperties.Hint="Uses edge detection to create an additional mask for sorting. Processed on device."
-                            ThumbColor="{AppThemeBinding Light={StaticResource Primary},
-                                                         Dark={StaticResource PrimaryDark}}"
-                            Toggled="UseCanny_Toggled"
-                            VerticalOptions="Center" />
-                    </Grid>
-
-                    <Grid
-                        x:Name="cannyMaskGrid"
-                        Padding="16,8"
-                        ColumnDefinitions="*, 60"
-                        IsVisible="{Binding IsToggled, Source={x:Reference useCannySwitch}}"
-                        RowDefinitions="Auto, Auto"
-                        RowSpacing="4">
-
-                        <Label
+                <!--  Image box  -->
+                <Border
+                    x:Name="imagePreviewBorder"
+                    Padding="12"
+                    BackgroundColor="{AppThemeBinding Light={StaticResource SurfaceLight},
+                                                      Dark={StaticResource SurfaceDark}}"
+                    Stroke="{AppThemeBinding Light={StaticResource DividerLight},
+                                             Dark={StaticResource DividerDark}}"
+                    StrokeShape="RoundRectangle 16"
+                    StrokeThickness="1"
+                    StyleClass="Elevation3">
+                    <Border.Shadow>
+                        <Shadow
+                            Brush="{AppThemeBinding Light={StaticResource Black},
+                                                    Dark={StaticResource White}}"
+                            Opacity="0.08"
+                            Radius="12"
+                            Offset="0,3" />
+                    </Border.Shadow>
+                    <Grid RowDefinitions="Auto,Auto">
+                        <local:ImageViewer
+                            x:Name="imageViewer"
                             Grid.Row="0"
-                            Grid.Column="0"
-                            Grid.ColumnSpan="2"
-                            FontAttributes="Bold"
-                            FontSize="16"
-                            Text="Threshold"
-                            VerticalOptions="Center" />
-
-                        <Slider
-                            x:Name="cannyValueSlider"
-                            Grid.Row="1"
-                            Grid.Column="0"
-                            Maximum="100"
-                            Minimum="1"
-                            SemanticProperties.Description="Canny threshold"
-                            ThumbColor="{AppThemeBinding Dark={StaticResource Primary},
-                                                         Light={StaticResource PrimaryDark}}"
-                            ValueChanged="OnCannySliderValueChanged"
-                            VerticalOptions="Center"
-                            Value="30" />
-
-                        <Label
-                            x:Name="cannySliderValue"
-                            Grid.Row="1"
-                            Grid.Column="1"
-                            FontSize="14"
-                            HorizontalOptions="End"
-                            TextColor="{AppThemeBinding Dark={StaticResource White},
-                                                        Light={StaticResource Black}}"
-                            VerticalOptions="Center" />
-                    </Grid>
-                    <BoxView
-                        Margin="16,0,0,0"
-                        HeightRequest="1"
-                        Color="{AppThemeBinding Light={StaticResource DividerLight},
-                                                Dark={StaticResource DividerDark}}" />
-
-                    <Grid
-                        Padding="16,0"
-                        ColumnDefinitions="*,Auto"
-                        HeightRequest="56">
-                        <Label
-                            FontSize="16"
-                            Text="Use subject masking"
-                            VerticalOptions="Center" />
-                        <Switch
-                            x:Name="useSubjectMaskingSwitch"
-                            Grid.Column="1"
-                            OnColor="{AppThemeBinding Light={StaticResource Secondary},
-                                                      Dark={StaticResource SecondaryDarkText}}"
-                            SemanticProperties.Description="Toggle switch to turn masking on or off"
-                            SemanticProperties.Hint="Requires internet the first time to download the model"
-                            ThumbColor="{AppThemeBinding Light={StaticResource Primary},
-                                                         Dark={StaticResource PrimaryDark}}"
-                            Toggled="useSubjectMaskingSwitch_Toggled"
-                            VerticalOptions="Center" />
-                    </Grid>
-
-                    <Grid
-                        x:Name="subjectMaskPaddingGrid"
-                        Padding="16,8"
-                        ColumnDefinitions="*, 60"
-                        IsVisible="{Binding IsToggled, Source={x:Reference useSubjectMaskingSwitch}}"
-                        RowDefinitions="Auto, Auto"
-                        RowSpacing="4">
-
-                        <Label
+                            HeightRequest="130"
+                            ImageTapped="LoadImage_Clicked"
+                            SemanticProperties.Description="Image viewer"
+                            StyleClass="Elevation5" />
+                        <Grid
+                            x:Name="loadingOverlay"
                             Grid.Row="0"
-                            Grid.Column="0"
-                            Grid.ColumnSpan="2"
-                            FontAttributes="Bold"
-                            FontSize="16"
-                            Text="Padding"
-                            VerticalOptions="Center" />
-                        <Slider
-                            x:Name="subjectMaskPadding"
+                            BackgroundColor="#80000000"
+                            InputTransparent="False"
+                            IsVisible="False"
+                            SemanticProperties.Description="Busy">
+                            <VerticalStackLayout
+                                HorizontalOptions="Center"
+                                Spacing="10"
+                                VerticalOptions="Center">
+                                <ActivityIndicator
+                                    x:Name="loadingIndicator"
+                                    HeightRequest="40"
+                                    IsRunning="False"
+                                    WidthRequest="40"
+                                    Color="{StaticResource White}" />
+                                <Label
+                                    x:Name="loadingOverlayLabel"
+                                    FontAttributes="Bold"
+                                    HorizontalTextAlignment="Center"
+                                    Text=""
+                                    TextColor="{StaticResource White}" />
+                            </VerticalStackLayout>
+                        </Grid>
+                        <Label
+                            x:Name="whatIsThisLabel"
                             Grid.Row="1"
-                            Grid.Column="0"
-                            Maximum="100"
-                            Minimum="1"
-                            SemanticProperties.Description="Subject mask padding"
-                            ThumbColor="{AppThemeBinding Dark={StaticResource Primary},
-                                                         Light={StaticResource PrimaryDark}}"
-                            ValueChanged="OnSubjectMaskingSliderValueChanged"
-                            VerticalOptions="Center"
-                            Value="15" />
-
-                        <Label
-                            x:Name="subjectPaddingSliderValue"
-                            Grid.Row="1"
-                            Grid.Column="1"
-                            FontSize="14"
-                            HorizontalOptions="End"
-                            TextColor="{AppThemeBinding Dark={StaticResource White},
-                                                        Light={StaticResource Black}}"
-                            VerticalOptions="Center" />
-                    </Grid>
-
-                    <Grid
-                        x:Name="whatToSortGrid"
-                        Padding="16,10"
-                        ColumnDefinitions="*,Auto"
-                        IsVisible="False">
-                        <Grid.Triggers>
-                            <MultiTrigger TargetType="Grid">
-                                <MultiTrigger.Conditions>
-                                    <BindingCondition Binding="{Binding IsToggled, Source={x:Reference useCannySwitch}}" Value="False" />
-                                    <BindingCondition Binding="{Binding IsToggled, Source={x:Reference useSubjectMaskingSwitch}}" Value="False" />
-                                </MultiTrigger.Conditions>
-                                <Setter Property="IsVisible" Value="False" />
-                            </MultiTrigger>
-                            <MultiTrigger TargetType="Grid">
-                                <MultiTrigger.Conditions>
-                                    <BindingCondition Binding="{Binding IsToggled, Source={x:Reference useSubjectMaskingSwitch}}" Value="True" />
-                                    <BindingCondition Binding="{Binding IsToggled, Source={x:Reference useCannySwitch}}" Value="False" />
-                                </MultiTrigger.Conditions>
-                                <Setter Property="IsVisible" Value="True" />
-                            </MultiTrigger>
-                        </Grid.Triggers>
-                        <Label
-                            FontSize="16"
-                            Text="What to sort"
-                            VerticalOptions="Center" />
-                        <HorizontalStackLayout
-                            Grid.Column="1"
-                            HorizontalOptions="End"
-                            Spacing="16"
-                            VerticalOptions="Center">
-                            <RadioButton
-                                x:Name="sortBackgroundRadio"
-                                CheckedChanged="WhatToSort_CheckedChanged"
-                                Content="Background"
-                                IsChecked="True"
-                                SemanticProperties.Description="Sort pixels in the background area" />
-                            <RadioButton
-                                x:Name="sortForegroundRadio"
-                                CheckedChanged="WhatToSort_CheckedChanged"
-                                Content="Foreground"
-                                SemanticProperties.Description="Sort pixels in the foreground area" />
-                        </HorizontalStackLayout>
-                    </Grid>
-
-                    <BoxView
-                        Margin="16,0,0,0"
-                        HeightRequest="1"
-                        IsVisible="False"
-                        Color="{AppThemeBinding Light={StaticResource DividerLight},
-                                                Dark={StaticResource DividerDark}}">
-                        <BoxView.Triggers>
-                            <MultiTrigger TargetType="BoxView">
-                                <MultiTrigger.Conditions>
-                                    <BindingCondition Binding="{Binding IsToggled, Source={x:Reference useCannySwitch}}" Value="True" />
-                                    <BindingCondition Binding="{Binding IsToggled, Source={x:Reference useSubjectMaskingSwitch}}" Value="True" />
-                                </MultiTrigger.Conditions>
-                                <Setter Property="IsVisible" Value="True" />
-                            </MultiTrigger>
-                        </BoxView.Triggers>
-                    </BoxView>
-
-                    <Grid
-                        x:Name="howToCombineGrid"
-                        Padding="16,10"
-                        ColumnDefinitions="*,Auto"
-                        IsVisible="False"
-                        RowDefinitions="Auto,Auto">
-                        <Grid.Triggers>
-                            <MultiTrigger TargetType="Grid">
-                                <MultiTrigger.Conditions>
-                                    <BindingCondition Binding="{Binding IsToggled, Source={x:Reference useCannySwitch}}" Value="True" />
-                                    <BindingCondition Binding="{Binding IsToggled, Source={x:Reference useSubjectMaskingSwitch}}" Value="True" />
-                                </MultiTrigger.Conditions>
-                                <Setter Property="IsVisible" Value="True" />
-                            </MultiTrigger>
-                        </Grid.Triggers>
-                        <Label
-                            FontSize="16"
-                            Text="How to combine masks"
-                            VerticalOptions="Center" />
-                        <HorizontalStackLayout
-                            Grid.Column="1"
-                            HorizontalOptions="End"
-                            Spacing="16"
-                            VerticalOptions="Center">
-                            <RadioButton
-                                x:Name="subMasksRadio"
-                                CheckedChanged="HowToCombine_CheckedChanged"
-                                Content="Subtract"
-                                IsChecked="True"
-                                SemanticProperties.Description="Subtracts the Canny mask from the subject mask." />
-                            <RadioButton
-                                x:Name="addMasksRadio"
-                                CheckedChanged="HowToCombine_CheckedChanged"
-                                Content="Add"
-                                SemanticProperties.Description="Adds the Canny mask and the subject mask." />
-                        </HorizontalStackLayout>
-                        <Label
-                            Grid.Row="1"
-                            Grid.ColumnSpan="2"
-                            Margin="0,4,0,0"
-                            Padding="2,2,2,2"
-                            FontSize="13"
-                            SemanticProperties.Description="Combining masks caption"
-                            Text="Canny and subject masks are combined when both masking options are on. The canny mask is used as second summand or as subtrahend for the subject mask"
+                            Margin="0,8,0,0"
+                            FontSize="12"
+                            HorizontalOptions="Center"
+                            SemanticProperties.Description="Current image caption"
+                            Text="Tap to load an image"
                             TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight},
                                                         Dark={StaticResource TextSecondaryDark}}"
-                            VerticalOptions="Start" />
+                            VerticalOptions="Center" />
                     </Grid>
-                </VerticalStackLayout>
-            </Border>
+                </Border>
 
+                <Label
+                    Margin="4,10,4,4"
+                    FontAttributes="Bold"
+                    FontSize="13"
+                    SemanticProperties.HeadingLevel="Level2"
+                    Text="SORT SETTINGS"
+                    TextColor="{AppThemeBinding Light={StaticResource Primary},
+                                                Dark={StaticResource PrimaryDark}}" />
+
+                <Border
+                    Padding="0"
+                    BackgroundColor="{AppThemeBinding Light={StaticResource SurfaceLight},
+                                                      Dark={StaticResource SurfaceDark}}"
+                    Stroke="{AppThemeBinding Light={StaticResource DividerLight},
+                                             Dark={StaticResource DividerDark}}"
+                    StrokeShape="RoundRectangle 12"
+                    StrokeThickness="1"
+                    StyleClass="Elevation3">
+                    <Border.Shadow>
+                        <Shadow
+                            Brush="{AppThemeBinding Light={StaticResource Black},
+                                                    Dark={StaticResource White}}"
+                            Opacity="0.10"
+                            Radius="10"
+                            Offset="0,3" />
+                    </Border.Shadow>
+                    <VerticalStackLayout Spacing="0">
+                        <VerticalStackLayout Padding="16,16,16,8" Spacing="16">
+                            <material:PickerField
+                                x:Name="sortBy"
+                                Title="Sort by"
+                                AccentColor="{AppThemeBinding Light={StaticResource Primary},
+                                                              Dark={StaticResource PrimaryDark}}"
+                                AllowClear="False"
+                                SemanticProperties.Description="A dropdown menu to select what to sort the Pixels by"
+                                TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight},
+                                                            Dark={StaticResource TextPrimaryDark}}" />
+                            <material:PickerField
+                                x:Name="sortDirection"
+                                Title="Direction"
+                                AccentColor="{AppThemeBinding Light={StaticResource Primary},
+                                                              Dark={StaticResource PrimaryDark}}"
+                                AllowClear="False"
+                                SemanticProperties.Description="A dropdown to select in what direction to sort the pixels"
+                                TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight},
+                                                            Dark={StaticResource TextPrimaryDark}}" />
+                        </VerticalStackLayout>
+                    </VerticalStackLayout>
+                </Border>
+
+                <Label
+                    Margin="4,10,4,4"
+                    FontAttributes="Bold"
+                    FontSize="13"
+                    SemanticProperties.HeadingLevel="Level2"
+                    Text="MASKING OPTIONS"
+                    TextColor="{AppThemeBinding Light={StaticResource Primary},
+                                                Dark={StaticResource PrimaryDark}}" />
+
+                <Border
+                    Padding="0"
+                    BackgroundColor="{AppThemeBinding Light={StaticResource SurfaceLight},
+                                                      Dark={StaticResource SurfaceDark}}"
+                    Stroke="{AppThemeBinding Light={StaticResource DividerLight},
+                                             Dark={StaticResource DividerDark}}"
+                    StrokeShape="RoundRectangle 12"
+                    StrokeThickness="1"
+                    StyleClass="Elevation3">
+                    <Border.Shadow>
+                        <Shadow
+                            Brush="{AppThemeBinding Light={StaticResource Black},
+                                                    Dark={StaticResource White}}"
+                            Opacity="0.10"
+                            Radius="10"
+                            Offset="0,3" />
+                    </Border.Shadow>
+                    <VerticalStackLayout Spacing="0">
+                        <Grid Padding="16,10" ColumnDefinitions="*,Auto">
+                            <Label
+                                FontSize="16"
+                                Text="Use Canny masking"
+                                VerticalOptions="Center" />
+                            <Switch
+                                x:Name="useCannySwitch"
+                                Grid.Column="1"
+                                OnColor="{AppThemeBinding Light={StaticResource Secondary},
+                                                          Dark={StaticResource SecondaryDarkText}}"
+                                SemanticProperties.Description="Toggle switch to turn masking with Canny on or off"
+                                SemanticProperties.Hint="Uses edge detection to create an additional mask for sorting. Processed on device."
+                                ThumbColor="{AppThemeBinding Light={StaticResource Primary},
+                                                             Dark={StaticResource PrimaryDark}}"
+                                Toggled="UseCanny_Toggled"
+                                VerticalOptions="Center" />
+                        </Grid>
+
+                        <Grid
+                            x:Name="cannyMaskGrid"
+                            Padding="16,8"
+                            ColumnDefinitions="*, 60"
+                            IsVisible="{Binding IsToggled, Source={x:Reference useCannySwitch}}"
+                            RowDefinitions="Auto, Auto"
+                            RowSpacing="4">
+
+                            <Label
+                                Grid.Row="0"
+                                Grid.Column="0"
+                                Grid.ColumnSpan="2"
+                                FontAttributes="Bold"
+                                FontSize="16"
+                                Text="Threshold"
+                                VerticalOptions="Center" />
+
+                            <Slider
+                                x:Name="cannyValueSlider"
+                                Grid.Row="1"
+                                Grid.Column="0"
+                                Maximum="99"
+                                Minimum="1"
+                                SemanticProperties.Description="Canny threshold"
+                                ThumbColor="{AppThemeBinding Dark={StaticResource Primary},
+                                                             Light={StaticResource PrimaryDark}}"
+                                ValueChanged="OnCannySliderValueChanged"
+                                VerticalOptions="Center"
+                                Value="30" />
+
+                            <Label
+                                x:Name="cannySliderValue"
+                                Grid.Row="1"
+                                Grid.Column="1"
+                                FontSize="14"
+                                HorizontalOptions="End"
+                                TextColor="{AppThemeBinding Dark={StaticResource White},
+                                                            Light={StaticResource Black}}"
+                                VerticalOptions="Center" />
+                        </Grid>
+                        <BoxView
+                            Margin="16,0,0,0"
+                            HeightRequest="1"
+                            Color="{AppThemeBinding Light={StaticResource DividerLight},
+                                                    Dark={StaticResource DividerDark}}" />
+
+                        <Grid
+                            Padding="16,0"
+                            ColumnDefinitions="*,Auto"
+                            HeightRequest="56">
+                            <Label
+                                FontSize="16"
+                                Text="Use subject masking"
+                                VerticalOptions="Center" />
+                            <Switch
+                                x:Name="useSubjectMaskingSwitch"
+                                Grid.Column="1"
+                                OnColor="{AppThemeBinding Light={StaticResource Secondary},
+                                                          Dark={StaticResource SecondaryDarkText}}"
+                                SemanticProperties.Description="Toggle switch to turn masking on or off"
+                                SemanticProperties.Hint="Requires internet the first time to download the model"
+                                ThumbColor="{AppThemeBinding Light={StaticResource Primary},
+                                                             Dark={StaticResource PrimaryDark}}"
+                                Toggled="useSubjectMaskingSwitch_Toggled"
+                                VerticalOptions="Center" />
+                        </Grid>
+
+                        <Grid
+                            x:Name="subjectMaskPaddingGrid"
+                            Padding="16,8"
+                            ColumnDefinitions="*, 60"
+                            IsVisible="{Binding IsToggled, Source={x:Reference useSubjectMaskingSwitch}}"
+                            RowDefinitions="Auto, Auto"
+                            RowSpacing="4">
+
+                            <Label
+                                Grid.Row="0"
+                                Grid.Column="0"
+                                Grid.ColumnSpan="2"
+                                FontAttributes="Bold"
+                                FontSize="16"
+                                Text="Padding"
+                                VerticalOptions="Center" />
+                            <Slider
+                                x:Name="subjectMaskPadding"
+                                Grid.Row="1"
+                                Grid.Column="0"
+                                Maximum="100"
+                                Minimum="1"
+                                SemanticProperties.Description="Subject mask padding"
+                                ThumbColor="{AppThemeBinding Dark={StaticResource Primary},
+                                                             Light={StaticResource PrimaryDark}}"
+                                ValueChanged="OnSubjectMaskingSliderValueChanged"
+                                VerticalOptions="Center"
+                                Value="15" />
+
+                            <Label
+                                x:Name="subjectPaddingSliderValue"
+                                Grid.Row="1"
+                                Grid.Column="1"
+                                FontSize="14"
+                                HorizontalOptions="End"
+                                TextColor="{AppThemeBinding Dark={StaticResource White},
+                                                            Light={StaticResource Black}}"
+                                VerticalOptions="Center" />
+                        </Grid>
+
+                        <Grid
+                            x:Name="whatToSortGrid"
+                            Padding="16,10"
+                            ColumnDefinitions="*,Auto"
+                            IsVisible="False">
+                            <Grid.Triggers>
+                                <MultiTrigger TargetType="Grid">
+                                    <MultiTrigger.Conditions>
+                                        <BindingCondition Binding="{Binding IsToggled, Source={x:Reference useCannySwitch}}" Value="False" />
+                                        <BindingCondition Binding="{Binding IsToggled, Source={x:Reference useSubjectMaskingSwitch}}" Value="False" />
+                                    </MultiTrigger.Conditions>
+                                    <Setter Property="IsVisible" Value="False" />
+                                </MultiTrigger>
+                                <MultiTrigger TargetType="Grid">
+                                    <MultiTrigger.Conditions>
+                                        <BindingCondition Binding="{Binding IsToggled, Source={x:Reference useSubjectMaskingSwitch}}" Value="True" />
+                                        <BindingCondition Binding="{Binding IsToggled, Source={x:Reference useCannySwitch}}" Value="False" />
+                                    </MultiTrigger.Conditions>
+                                    <Setter Property="IsVisible" Value="True" />
+                                </MultiTrigger>
+                            </Grid.Triggers>
+                            <Label
+                                FontSize="16"
+                                Text="What to sort"
+                                VerticalOptions="Center" />
+                            <HorizontalStackLayout
+                                Grid.Column="1"
+                                HorizontalOptions="End"
+                                Spacing="16"
+                                VerticalOptions="Center">
+                                <RadioButton
+                                    x:Name="sortBackgroundRadio"
+                                    CheckedChanged="WhatToSort_CheckedChanged"
+                                    Content="Background"
+                                    IsChecked="True"
+                                    SemanticProperties.Description="Sort pixels in the background area" />
+                                <RadioButton
+                                    x:Name="sortForegroundRadio"
+                                    CheckedChanged="WhatToSort_CheckedChanged"
+                                    Content="Foreground"
+                                    SemanticProperties.Description="Sort pixels in the foreground area" />
+                            </HorizontalStackLayout>
+                        </Grid>
+
+                        <BoxView
+                            Margin="16,0,0,0"
+                            HeightRequest="1"
+                            IsVisible="False"
+                            Color="{AppThemeBinding Light={StaticResource DividerLight},
+                                                    Dark={StaticResource DividerDark}}">
+                            <BoxView.Triggers>
+                                <MultiTrigger TargetType="BoxView">
+                                    <MultiTrigger.Conditions>
+                                        <BindingCondition Binding="{Binding IsToggled, Source={x:Reference useCannySwitch}}" Value="True" />
+                                        <BindingCondition Binding="{Binding IsToggled, Source={x:Reference useSubjectMaskingSwitch}}" Value="True" />
+                                    </MultiTrigger.Conditions>
+                                    <Setter Property="IsVisible" Value="True" />
+                                </MultiTrigger>
+                            </BoxView.Triggers>
+                        </BoxView>
+
+                        <Grid
+                            x:Name="howToCombineGrid"
+                            Padding="16,10"
+                            ColumnDefinitions="*,Auto"
+                            IsVisible="False"
+                            RowDefinitions="Auto,Auto">
+                            <Grid.Triggers>
+                                <MultiTrigger TargetType="Grid">
+                                    <MultiTrigger.Conditions>
+                                        <BindingCondition Binding="{Binding IsToggled, Source={x:Reference useCannySwitch}}" Value="True" />
+                                        <BindingCondition Binding="{Binding IsToggled, Source={x:Reference useSubjectMaskingSwitch}}" Value="True" />
+                                    </MultiTrigger.Conditions>
+                                    <Setter Property="IsVisible" Value="True" />
+                                </MultiTrigger>
+                            </Grid.Triggers>
+                            <Label
+                                FontSize="16"
+                                Text="How to combine masks"
+                                VerticalOptions="Center" />
+                            <HorizontalStackLayout
+                                Grid.Column="1"
+                                HorizontalOptions="End"
+                                Spacing="16"
+                                VerticalOptions="Center">
+                                <RadioButton
+                                    x:Name="subMasksRadio"
+                                    CheckedChanged="HowToCombine_CheckedChanged"
+                                    Content="Subtract"
+                                    IsChecked="True"
+                                    SemanticProperties.Description="Subtracts the Canny mask from the subject mask." />
+                                <RadioButton
+                                    x:Name="addMasksRadio"
+                                    CheckedChanged="HowToCombine_CheckedChanged"
+                                    Content="Add"
+                                    SemanticProperties.Description="Adds the Canny mask and the subject mask." />
+                            </HorizontalStackLayout>
+                            <Label
+                                Grid.Row="1"
+                                Grid.ColumnSpan="2"
+                                Margin="0,4,0,0"
+                                Padding="2,2,2,2"
+                                FontSize="13"
+                                SemanticProperties.Description="Combining masks caption"
+                                Text="Canny and subject masks are combined when both masking options are on. The canny mask is used as second summand or as subtrahend for the subject mask"
+                                TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight},
+                                                            Dark={StaticResource TextSecondaryDark}}"
+                                VerticalOptions="Start" />
+                        </Grid>
+                    </VerticalStackLayout>
+                </Border>
+
+                <Button
+                    x:Name="saveBtn"
+                    Margin="0,16,0,0"
+                    Clicked="SaveBtn_Clicked"
+                    HorizontalOptions="Fill"
+                    IsVisible="False"
+                    SemanticProperties.Description="Save the current image to your photo gallery"
+                    Style="{StaticResource SaveButtonStyle}"
+                    Text="Save" />
+
+            </VerticalStackLayout>
+        </ScrollView>
+
+        <VerticalStackLayout
+            Grid.Row="1"
+            Padding="20,8,20,16"
+            BackgroundColor="{AppThemeBinding Light={StaticResource PageBackgroundLight},
+                                              Dark={StaticResource PageBackgroundDark}}">
             <Button
-                x:Name="saveBtn"
-                Clicked="SaveBtn_Clicked"
-                Margin="0,16,0,0"
-                Style="{StaticResource SaveButtonStyle}"
+                x:Name="sortBtn"
+                Clicked="SortBtn_Clicked"
                 HorizontalOptions="Fill"
-                IsVisible="False"
-                SemanticProperties.Description="Save the current image to your photo gallery"
-                Text="Save" />
-
+                SemanticProperties.Description="Start pixel sorting"
+                Text="Sort" />
         </VerticalStackLayout>
-    </ScrollView>
-
-    <VerticalStackLayout
-        Grid.Row="1"
-        Padding="20,8,20,16"
-        BackgroundColor="{AppThemeBinding Light={StaticResource PageBackgroundLight}, Dark={StaticResource PageBackgroundDark}}">
-        <Button
-            x:Name="sortBtn"
-            Clicked="SortBtn_Clicked"
-            HorizontalOptions="Fill"
-            SemanticProperties.Description="Start pixel sorting"
-            Text="Sort" />
-    </VerticalStackLayout>
-</Grid>
+    </Grid>
 </ContentPage>

--- a/PixelsorterApp/MainPage.xaml.cs
+++ b/PixelsorterApp/MainPage.xaml.cs
@@ -28,7 +28,7 @@ namespace PixelsorterApp
         private readonly List<string> imagePaths = [];
         private int currentDisplayedImageIndex = -1;
         private int subjectMaskPaddingAmount = 15;
-        private int cannyThreashold = 30;
+        private float cannyThreashold = 0.3f;
         private bool useInvertedMask = false;
         private bool useSubtractMasks = true;
         private NDArray? backgroundMask = null;
@@ -342,7 +342,7 @@ namespace PixelsorterApp
                 {
                     try
                     {
-                        (this.backgroundMask, this.invertedBackgroundMask) = await backgroundMasker.GetMaskAsync(this.imagePath, this.subjectMaskPaddingAmount);
+                        (this.backgroundMask, this.invertedBackgroundMask) = await backgroundMasker.GetMaskAsync(this.imagePath, new BackgroundMaskOptions(this.subjectMaskPaddingAmount));
                         return true;
                     }
                     catch (Exception ex)
@@ -370,7 +370,7 @@ namespace PixelsorterApp
             {
                 try
                 {
-                    (this.cannyMask, this.invertedCannyMask) = await cannyMasker.GetMaskAsync(this.imagePath, this.cannyThreashold);
+                    (this.cannyMask, this.invertedCannyMask) = await cannyMasker.GetMaskAsync(this.imagePath, new CannyMaskOptions(this.cannyThreashold));
                     return true;
                 }
                 catch (Exception ex)
@@ -663,7 +663,7 @@ namespace PixelsorterApp
             {
                 cannyValueSlider.Value = value;
             }
-            this.cannyThreashold = (int)e.NewValue;
+            this.cannyThreashold = (int)e.NewValue / 100f;
             cannySliderValue.Text = $"{value}%";
 
             this.cannyMask = null; // Clear existing masks to ensure they are regenerated with the new padding


### PR DESCRIPTION
## Description
Adjusted mask creation to use new MaskOptions to addapt to the classLib changes. Also limmited Canny threshold to range (0,100) as classLib requires.

Autoformater formated MainPage XAML.

## Related Issue
https://github.com/h43lb1t0/PixelsorterClassLib/pull/16

## 🍎 Apple Platform Testing
<!-- IMPORTANT: The maintainer DOES NOT own an Apple device. If your changes affect iOS or MacCatalyst, you MUST test them yourself and provide proof of functionality. -->
- [x] My changes do NOT affect iOS or MacCatalyst.
- [ ] My changes affect iOS/MacCatalyst, and I have tested them thoroughly on a device/simulator. 
<!-- If you checked the second box, please attach screenshots, screen recordings, or describe your testing process below: -->


## Checklist:
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have built the solution and verified that it complies successfully.
- [x] I have tested my changes on Windows and/or Android (or they are platform-agnostic).
- [x] I have adhered to the existing UI styling (e.g., flat layouts, non-editable looking pickers, visually distinct disabled buttons).
- [x] My changes generate no new warnings.
