### PR TITLE
fix(imageviewer): use CurrentItem instead of ScrollTo for CarouselView to scroll no newest image

### DIFF
--- a/PixelsorterApp/Platforms/Android/ImageViewer.cs
+++ b/PixelsorterApp/Platforms/Android/ImageViewer.cs
@@ -40,17 +40,20 @@ public partial class ImageViewer
     public partial void ShowImage(string filePath)
     {
         var newImage = ImageSource.FromFile(filePath);
-        _images.Add(newImage);
-
         SetHeightFromImage(filePath);
 
-        if (_carousel is not null)
+        Dispatcher.Dispatch(() =>
         {
-            if (_carousel.ItemsSource is null)
-                _carousel.ItemsSource = _images;
+            _images.Add(newImage);
 
-            _carousel.CurrentItem = newImage;
-        }
+            if (_carousel is not null)
+            {
+                if (_carousel.ItemsSource is null)
+                    _carousel.ItemsSource = _images;
+
+                _carousel.CurrentItem = newImage;
+            }
+        });
 
     }
 

--- a/PixelsorterApp/Platforms/Android/ImageViewer.cs
+++ b/PixelsorterApp/Platforms/Android/ImageViewer.cs
@@ -39,7 +39,8 @@ public partial class ImageViewer
 
     public partial void ShowImage(string filePath)
     {
-        _images.Add(ImageSource.FromFile(filePath));
+        var newImage = ImageSource.FromFile(filePath);
+        _images.Add(newImage);
 
         SetHeightFromImage(filePath);
 
@@ -48,8 +49,7 @@ public partial class ImageViewer
             if (_carousel.ItemsSource is null)
                 _carousel.ItemsSource = _images;
 
-            var targetIndex = _images.Count - 1;
-            Dispatcher.Dispatch(() => _carousel.ScrollTo(targetIndex, animate: true)); //Scrolls to latest image
+            _carousel.CurrentItem = newImage;
         }
 
     }


### PR DESCRIPTION
## Description
Grouped _images.Add(newImage) and the scroll operation into a single Dispatch call preventing timing mismatches.
Instead of using the ScrollTo method to navigate to a newly added image, the image is now assigned directly to the CurrentItem property of the CarouselView. Making the scroll animation clearer.


## Related Issue
Fixes #42 

## 🍎 Apple Platform Testing
<!-- IMPORTANT: The maintainer DOES NOT own an Apple device. If your changes affect iOS or MacCatalyst, you MUST test them yourself and provide proof of functionality. -->
- [x] My changes do NOT affect iOS or MacCatalyst.
- [ ] My changes affect iOS/MacCatalyst, and I have tested them thoroughly on a device/simulator. 
<!-- If you checked the second box, please attach screenshots, screen recordings, or describe your testing process below: -->


## Checklist:
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have built the solution and verified that it complies successfully.
- [x] I have tested my changes on Windows and/or Android (or they are platform-agnostic).
- [x] I have adhered to the existing UI styling (e.g., flat layouts, non-editable looking pickers, visually distinct disabled buttons).
- [x] My changes generate no new warnings.
