### PR TITLE
Clean main page view model

### DIFF
--- a/PixelsorterApp/App.xaml.cs
+++ b/PixelsorterApp/App.xaml.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-
-namespace PixelsorterApp
+﻿namespace PixelsorterApp
 {
     /// <summary>
     /// Application root that composes shell and initial navigation window.

--- a/PixelsorterApp/Extensions/BorderAnimationExtensions.cs
+++ b/PixelsorterApp/Extensions/BorderAnimationExtensions.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.Maui.Controls;
-
-namespace PixelsorterApp.Extensions;
+﻿namespace PixelsorterApp.Extensions;
 
 public static class BorderAnimationExtensions
 {

--- a/PixelsorterApp/MauiProgram.cs
+++ b/PixelsorterApp/MauiProgram.cs
@@ -1,4 +1,4 @@
-﻿using CommunityToolkit.Maui;
+using CommunityToolkit.Maui;
 using Indiko.Maui.Controls.Markdown;
 using Microsoft.Extensions.Logging;
 using PixelsorterApp.Services;
@@ -36,6 +36,7 @@ namespace PixelsorterApp
             builder.Services.AddTransient<PresetsPageViewModel>();
             builder.Services.AddSingleton<IImageProcessingService, ImageProcessingService>();
             builder.Services.AddSingleton<ITomlValidationService, TomlValidationService>();
+            builder.Services.AddSingleton<IPresetService, PresetService>();
             builder.Services.AddSingleton<IHelpNavigationService, HelpNavigationService>();
             builder.Services.AddSingleton<IPresetNavigationService, PresetNavigationService>();
 

--- a/PixelsorterApp/Models/Presets/PresetModels.cs
+++ b/PixelsorterApp/Models/Presets/PresetModels.cs
@@ -1,0 +1,98 @@
+using System.Text.Json.Serialization;
+using Tomlyn.Serialization;
+
+namespace PixelsorterApp.Models.Presets;
+
+/// <summary>
+/// Represents a collection of TOML mapping configurations for sorting and masking operations.
+/// </summary>
+public sealed class TomlMap
+{
+    [JsonPropertyName("sortBy")]
+    public Dictionary<string, string>? SortBy { get; init; }
+
+    [JsonPropertyName("direction")]
+    public Dictionary<string, string>? Direction { get; init; }
+
+    [JsonPropertyName("maskCombination")]
+    public Dictionary<string, string>? MaskCombination { get; init; }
+
+    [JsonPropertyName("whatToSort")]
+    public Dictionary<string, string>? WhatToSort { get; init; }
+}
+
+/// <summary>
+/// Represents a deserialized TOML preset containing configuration options for sorting, masking, edge detection,
+/// subject settings, and mask combination.
+/// </summary>
+public sealed class PresetToml
+{
+    [TomlPropertyName("sort_settings")]
+    public SortSettings? SortSettings { get; init; }
+
+    [TomlPropertyName("masking_options")]
+    public MaskingOptions? MaskingOptions { get; init; }
+
+    [TomlPropertyName("canny_options")]
+    public CannyOptions? CannyOptions { get; init; }
+
+    [TomlPropertyName("subject_settings")]
+    public SubjectSettings? SubjectSettings { get; init; }
+
+    [TomlPropertyName("mask_combination")]
+    public MaskCombination? MaskCombination { get; init; }
+}
+
+/// <summary>
+/// Represents the configuration settings for sorting, including the property to sort by and the sort direction.
+/// </summary>
+public sealed class SortSettings
+{
+    [TomlPropertyName("sort_by")]
+    public string? SortBy { get; init; }
+
+    [TomlPropertyName("direction")]
+    public string? Direction { get; init; }
+}
+
+/// <summary>
+/// Represents configuration options for controlling masking behavior in image processing operations.
+/// </summary>
+public sealed class MaskingOptions
+{
+    [TomlPropertyName("use_canny")]
+    public bool UseCanny { get; init; }
+
+    [TomlPropertyName("use_subject")]
+    public bool UseSubject { get; init; }
+}
+
+/// <summary>
+/// Represents configuration options for the Canny edge detection algorithm.
+/// </summary>
+public sealed class CannyOptions
+{
+    [TomlPropertyName("threshold")]
+    public int? Threshold { get; init; }
+}
+
+/// <summary>
+/// Represents configuration options for subject-based masking.
+/// </summary>
+public sealed class SubjectSettings
+{
+    [TomlPropertyName("padding")]
+    public int? Padding { get; init; }
+
+    [TomlPropertyName("what_to_sort")]
+    public string? WhatToSort { get; init; }
+}
+
+/// <summary>
+/// Represents a combination of masks used for configuration settings.
+/// </summary>
+public sealed class MaskCombination
+{
+    [TomlPropertyName("mode")]
+    public string? Mode { get; init; }
+}

--- a/PixelsorterApp/Models/Presets/PresetState.cs
+++ b/PixelsorterApp/Models/Presets/PresetState.cs
@@ -1,0 +1,16 @@
+namespace PixelsorterApp.Models.Presets;
+
+/// <summary>
+/// Represents the parsed state of a preset to be applied to the ViewModel.
+/// </summary>
+public sealed class PresetState
+{
+    public bool? UseCanny { get; set; }
+    public bool? UseSubjectMask { get; set; }
+    public int? CannyThresholdPercent { get; set; }
+    public int? SubjectMaskPadding { get; set; }
+    public bool? UseInvertedSubjectMask { get; set; }
+    public string? SortByName { get; set; }
+    public bool? UseSubtractMasks { get; set; }
+    public string? DirectionName { get; set; }
+}

--- a/PixelsorterApp/Models/Presets/PresetState.cs
+++ b/PixelsorterApp/Models/Presets/PresetState.cs
@@ -5,12 +5,12 @@ namespace PixelsorterApp.Models.Presets;
 /// </summary>
 public sealed class PresetState
 {
-    public bool? UseCanny { get; set; }
-    public bool? UseSubjectMask { get; set; }
-    public int? CannyThresholdPercent { get; set; }
-    public int? SubjectMaskPadding { get; set; }
-    public bool? UseInvertedSubjectMask { get; set; }
-    public string? SortByName { get; set; }
-    public bool? UseSubtractMasks { get; set; }
-    public string? DirectionName { get; set; }
+    public bool? UseCanny { get; init; }
+    public bool? UseSubjectMask { get; init; }
+    public int? CannyThresholdPercent { get; init; }
+    public int? SubjectMaskPadding { get; init; }
+    public bool? UseInvertedSubjectMask { get; init; }
+    public string? SortByName { get; init; }
+    public bool? UseSubtractMasks { get; init; }
+    public string? DirectionName { get; init; }
 }

--- a/PixelsorterApp/Pages/PresetsPage.xaml
+++ b/PixelsorterApp/Pages/PresetsPage.xaml
@@ -135,7 +135,7 @@
                             Text="Delete" />
                     </Grid>
 
-                    <CollectionView ItemsSource="{Binding AvilablePresets}">
+                    <CollectionView ItemsSource="{Binding AvailablePresets}">
                         <CollectionView.ItemTemplate>
                             <DataTemplate x:DataType="viewModels:PresetsPageViewModel+PresetListItem">
                                 <Grid

--- a/PixelsorterApp/Services/IPresetService.cs
+++ b/PixelsorterApp/Services/IPresetService.cs
@@ -23,4 +23,10 @@ public interface IPresetService
     /// <param name="presetPath">The path to the preset file to load.</param>
     /// <returns>The parsed state, or null if loading/parsing fails.</returns>
     Task<PresetState?> LoadPresetAsync(string presetPath);
+
+    /// <summary>
+    /// Asynchronously gets the cached TOML map.
+    /// </summary>
+    /// <returns>The parsed TomlMap, or null if loading fails.</returns>
+    Task<TomlMap?> GetTomlMapAsync();
 }

--- a/PixelsorterApp/Services/IPresetService.cs
+++ b/PixelsorterApp/Services/IPresetService.cs
@@ -1,0 +1,28 @@
+using PixelsorterApp.Models.Presets;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace PixelsorterApp.Services;
+
+/// <summary>
+/// Provides methods for discovering, loading, and parsing presets.
+/// </summary>
+public interface IPresetService
+{
+    /// <summary>
+    /// Gets a dictionary of available preset names to their file paths.
+    /// </summary>
+    IReadOnlyDictionary<string, string> GetAvailablePresets();
+
+    /// <summary>
+    /// Finds the default preset option key.
+    /// </summary>
+    string? FindDefaultPresetOption(IReadOnlyDictionary<string, string> availablePresets);
+
+    /// <summary>
+    /// Asynchronously loads a preset from the specified path and returns its parsed state.
+    /// </summary>
+    /// <param name="presetPath">The path to the preset file to load.</param>
+    /// <returns>The parsed state, or null if loading/parsing fails.</returns>
+    Task<PresetState?> LoadPresetAsync(string presetPath);
+}

--- a/PixelsorterApp/Services/IPresetService.cs
+++ b/PixelsorterApp/Services/IPresetService.cs
@@ -1,6 +1,4 @@
 using PixelsorterApp.Models.Presets;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 
 namespace PixelsorterApp.Services;
 

--- a/PixelsorterApp/Services/ITomlValidationService.cs
+++ b/PixelsorterApp/Services/ITomlValidationService.cs
@@ -1,8 +1,10 @@
-﻿namespace PixelsorterApp.Services
+using PixelsorterApp.Models.Presets;
+
+namespace PixelsorterApp.Services
 {
     public interface ITomlValidationService
     {
-        Task<(bool isValid, string errors)> Validate(string content);
+        Task<(bool isValid, string errors)> Validate(string content, TomlMap? map);
 
         string Sanitize(string content);
     }

--- a/PixelsorterApp/Services/ImageProcessingService.cs
+++ b/PixelsorterApp/Services/ImageProcessingService.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
 using NumSharp;
 using PixelsorterClassLib.Core;
 using PixelsorterClassLib.Masks;

--- a/PixelsorterApp/Services/PresetNavigationService.cs
+++ b/PixelsorterApp/Services/PresetNavigationService.cs
@@ -1,11 +1,10 @@
-using Microsoft.Extensions.DependencyInjection;
 using PixelsorterApp.Pages;
 
 namespace PixelsorterApp.Services;
 
 public sealed class PresetNavigationService : IPresetNavigationService
 {
-   private readonly IServiceProvider serviceProvider;
+    private readonly IServiceProvider serviceProvider;
 
     public PresetNavigationService(IServiceProvider serviceProvider)
     {
@@ -20,6 +19,6 @@ public sealed class PresetNavigationService : IPresetNavigationService
             return;
         }
 
-      await currentPage.Navigation.PushAsync(serviceProvider.GetRequiredService<PresetsPage>());
+        await currentPage.Navigation.PushAsync(serviceProvider.GetRequiredService<PresetsPage>());
     }
 }

--- a/PixelsorterApp/Services/PresetService.cs
+++ b/PixelsorterApp/Services/PresetService.cs
@@ -1,11 +1,5 @@
 using PixelsorterApp.Models.Presets;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Text.Json;
-using System.Threading.Tasks;
-using Tomlyn;
 
 namespace PixelsorterApp.Services;
 

--- a/PixelsorterApp/Services/PresetService.cs
+++ b/PixelsorterApp/Services/PresetService.cs
@@ -1,0 +1,197 @@
+using PixelsorterApp.Models.Presets;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Tomlyn;
+
+namespace PixelsorterApp.Services;
+
+public class PresetService : IPresetService
+{
+    private readonly ITomlValidationService _tomlValidationService;
+
+    private readonly string _defaultPresetPreference = Preferences.Get("defaultPreset", "base.toml");
+    private readonly string _basePresetPath = "presets/base.toml";
+    private readonly string _userPresetsPath = Path.Combine(FileSystem.Current.AppDataDirectory, "Presets");
+    private const string TomlMapPath = "presets/tomlMap.json";
+
+    public PresetService(ITomlValidationService tomlValidationService)
+    {
+        _tomlValidationService = tomlValidationService;
+    }
+
+    public IReadOnlyDictionary<string, string> GetAvailablePresets()
+    {
+        var availablePresets = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        try
+        {
+            availablePresets.Add("Base", _basePresetPath);
+
+            if (Directory.Exists(_userPresetsPath))
+            {
+                var files = Directory.GetFiles(_userPresetsPath, "*.toml");
+                foreach (var file in files)
+                {
+                    availablePresets[Path.GetFileNameWithoutExtension(file)] = file;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Error loading presets: {ex}");
+        }
+
+        return availablePresets;
+    }
+
+    public string? FindDefaultPresetOption(IReadOnlyDictionary<string, string> availablePresets)
+    {
+        string normalizedDefaultPreset = Path.GetFileName(_defaultPresetPreference);
+
+        foreach (var preset in availablePresets)
+        {
+            if (string.Equals(preset.Key, _defaultPresetPreference, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(preset.Value, _defaultPresetPreference, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(Path.GetFileName(preset.Value), normalizedDefaultPreset, StringComparison.OrdinalIgnoreCase))
+            {
+                return preset.Key;
+            }
+        }
+
+        return null;
+    }
+
+    public async Task<PresetState?> LoadPresetAsync(string presetPath)
+    {
+        try
+        {
+            var tomlContent = Path.IsPathRooted(presetPath)
+                ? await File.ReadAllTextAsync(presetPath)
+                : await ReadAppPackageTextAsync(presetPath);
+
+            var mapContent = await ReadAppPackageTextAsync(TomlMapPath);
+
+            var map = JsonSerializer.Deserialize<TomlMap>(mapContent, new JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true,
+            });
+
+            if (map is null)
+            {
+                return null;
+            }
+
+            return ApplyPreset(tomlContent, map);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"Failed to load preset: {ex}");
+            return null;
+        }
+    }
+
+    private PresetState? ApplyPreset(string tomlContent, TomlMap map)
+    {
+        var sanitizedToml = _tomlValidationService.Sanitize(tomlContent);
+
+        if (!Tomlyn.TomlSerializer.TryDeserialize(sanitizedToml, out PresetToml? preset, null) || preset is null)
+        {
+            return null;
+        }
+
+        var state = new PresetState();
+
+        if (preset.MaskingOptions is not null)
+        {
+            state.UseCanny = preset.MaskingOptions.UseCanny;
+            state.UseSubjectMask = preset.MaskingOptions.UseSubject;
+        }
+
+        if (preset.CannyOptions is not null)
+        {
+            var threshold = preset.CannyOptions.Threshold;
+            if (threshold is > 0)
+            {
+                state.CannyThresholdPercent = threshold.Value;
+            }
+        }
+
+        if (preset.SubjectSettings is not null)
+        {
+            if (preset.SubjectSettings.Padding is > 0)
+            {
+                state.SubjectMaskPadding = preset.SubjectSettings.Padding.Value;
+            }
+
+            if (!string.IsNullOrWhiteSpace(preset.SubjectSettings.WhatToSort))
+            {
+                if (TryGetMappedValue(map.WhatToSort, preset.SubjectSettings.WhatToSort, out var whatToSortMapped))
+                {
+                    state.UseInvertedSubjectMask = string.Equals(
+                        whatToSortMapped,
+                        "SortForegroundSelected",
+                        StringComparison.Ordinal);
+                }
+                else
+                {
+                    state.UseInvertedSubjectMask = string.Equals(preset.SubjectSettings.WhatToSort, "foreground", StringComparison.OrdinalIgnoreCase);
+                }
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(preset.SortSettings?.SortBy)
+            && TryGetMappedValue(map.SortBy, preset.SortSettings.SortBy, out var sortByMapped))
+        {
+            state.SortByName = sortByMapped.Split('.').Last();
+        }
+
+        if (!string.IsNullOrWhiteSpace(preset.MaskCombination?.Mode)
+            && TryGetMappedValue(map.MaskCombination, preset.MaskCombination.Mode, out var maskCombinationMapped))
+        {
+            state.UseSubtractMasks = string.Equals(
+                maskCombinationMapped,
+                "UseSubtractMasksSelected",
+                StringComparison.Ordinal);
+        }
+
+        if (!string.IsNullOrWhiteSpace(preset.SortSettings?.Direction)
+            && TryGetMappedValue(map.Direction, preset.SortSettings.Direction, out var directionMapped))
+        {
+            state.DirectionName = directionMapped.Split('.').Last();
+        }
+
+        return state;
+    }
+
+    private static bool TryGetMappedValue(IReadOnlyDictionary<string, string>? map, string key, out string value)
+    {
+        value = string.Empty;
+
+        if (map is null)
+        {
+            return false;
+        }
+
+        foreach (var pair in map)
+        {
+            if (string.Equals(pair.Key, key, StringComparison.OrdinalIgnoreCase))
+            {
+                value = pair.Value;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static async Task<string> ReadAppPackageTextAsync(string path)
+    {
+        using var stream = await FileSystem.OpenAppPackageFileAsync(path);
+        using var reader = new StreamReader(stream);
+        return await reader.ReadToEndAsync();
+    }
+}

--- a/PixelsorterApp/Services/PresetService.cs
+++ b/PixelsorterApp/Services/PresetService.cs
@@ -1,5 +1,6 @@
 using PixelsorterApp.Models.Presets;
 using System.Text.Json;
+using PixelsorterApp.ViewModels;
 
 namespace PixelsorterApp.Services;
 
@@ -7,10 +8,10 @@ public class PresetService : IPresetService
 {
     private readonly ITomlValidationService _tomlValidationService;
 
-    private readonly string _defaultPresetPreference = Preferences.Get("defaultPreset", "base.toml");
     private readonly string _basePresetPath = "presets/base.toml";
     private readonly string _userPresetsPath = Path.Combine(FileSystem.Current.AppDataDirectory, "Presets");
     private const string TomlMapPath = "presets/tomlMap.json";
+    private TomlMap? _cachedMap;
 
     public PresetService(ITomlValidationService tomlValidationService)
     {
@@ -44,12 +45,13 @@ public class PresetService : IPresetService
 
     public string? FindDefaultPresetOption(IReadOnlyDictionary<string, string> availablePresets)
     {
-        string normalizedDefaultPreset = Path.GetFileName(_defaultPresetPreference);
+        string defaultPresetPreference = Preferences.Get("defaultPreset", "base.toml");
+        string normalizedDefaultPreset = Path.GetFileName(defaultPresetPreference);
 
         foreach (var preset in availablePresets)
         {
-            if (string.Equals(preset.Key, _defaultPresetPreference, StringComparison.OrdinalIgnoreCase)
-                || string.Equals(preset.Value, _defaultPresetPreference, StringComparison.OrdinalIgnoreCase)
+            if (string.Equals(preset.Key, defaultPresetPreference, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(preset.Value, defaultPresetPreference, StringComparison.OrdinalIgnoreCase)
                 || string.Equals(Path.GetFileName(preset.Value), normalizedDefaultPreset, StringComparison.OrdinalIgnoreCase))
             {
                 return preset.Key;
@@ -65,14 +67,9 @@ public class PresetService : IPresetService
         {
             var tomlContent = Path.IsPathRooted(presetPath)
                 ? await File.ReadAllTextAsync(presetPath)
-                : await ReadAppPackageTextAsync(presetPath);
+                : await BaseViewModel.ReadAppPackageTextAsync(presetPath);
 
-            var mapContent = await ReadAppPackageTextAsync(TomlMapPath);
-
-            var map = JsonSerializer.Deserialize<TomlMap>(mapContent, new JsonSerializerOptions
-            {
-                PropertyNameCaseInsensitive = true,
-            });
+            var map = await GetTomlMapAsync();
 
             if (map is null)
             {
@@ -97,68 +94,61 @@ public class PresetService : IPresetService
             return null;
         }
 
-        var state = new PresetState();
-
-        if (preset.MaskingOptions is not null)
-        {
-            state.UseCanny = preset.MaskingOptions.UseCanny;
-            state.UseSubjectMask = preset.MaskingOptions.UseSubject;
-        }
-
-        if (preset.CannyOptions is not null)
-        {
-            var threshold = preset.CannyOptions.Threshold;
-            if (threshold is > 0)
-            {
-                state.CannyThresholdPercent = threshold.Value;
-            }
-        }
+        bool? useInvertedSubjectMask = null;
+        int? subjectMaskPadding = null;
 
         if (preset.SubjectSettings is not null)
         {
             if (preset.SubjectSettings.Padding is > 0)
             {
-                state.SubjectMaskPadding = preset.SubjectSettings.Padding.Value;
+                subjectMaskPadding = preset.SubjectSettings.Padding.Value;
             }
 
             if (!string.IsNullOrWhiteSpace(preset.SubjectSettings.WhatToSort))
             {
                 if (TryGetMappedValue(map.WhatToSort, preset.SubjectSettings.WhatToSort, out var whatToSortMapped))
                 {
-                    state.UseInvertedSubjectMask = string.Equals(
-                        whatToSortMapped,
-                        "SortForegroundSelected",
-                        StringComparison.Ordinal);
+                    useInvertedSubjectMask = string.Equals(whatToSortMapped, "SortForegroundSelected", StringComparison.Ordinal);
                 }
                 else
                 {
-                    state.UseInvertedSubjectMask = string.Equals(preset.SubjectSettings.WhatToSort, "foreground", StringComparison.OrdinalIgnoreCase);
+                    useInvertedSubjectMask = string.Equals(preset.SubjectSettings.WhatToSort, "foreground", StringComparison.OrdinalIgnoreCase);
                 }
             }
         }
 
+        string? sortByName = null;
         if (!string.IsNullOrWhiteSpace(preset.SortSettings?.SortBy)
             && TryGetMappedValue(map.SortBy, preset.SortSettings.SortBy, out var sortByMapped))
         {
-            state.SortByName = sortByMapped.Split('.').Last();
+            sortByName = sortByMapped.Split('.').Last();
         }
 
+        bool? useSubtractMasks = null;
         if (!string.IsNullOrWhiteSpace(preset.MaskCombination?.Mode)
             && TryGetMappedValue(map.MaskCombination, preset.MaskCombination.Mode, out var maskCombinationMapped))
         {
-            state.UseSubtractMasks = string.Equals(
-                maskCombinationMapped,
-                "UseSubtractMasksSelected",
-                StringComparison.Ordinal);
+            useSubtractMasks = string.Equals(maskCombinationMapped, "UseSubtractMasksSelected", StringComparison.Ordinal);
         }
 
+        string? directionName = null;
         if (!string.IsNullOrWhiteSpace(preset.SortSettings?.Direction)
             && TryGetMappedValue(map.Direction, preset.SortSettings.Direction, out var directionMapped))
         {
-            state.DirectionName = directionMapped.Split('.').Last();
+            directionName = directionMapped.Split('.').Last();
         }
 
-        return state;
+        return new PresetState
+        {
+            UseCanny = preset.MaskingOptions?.UseCanny,
+            UseSubjectMask = preset.MaskingOptions?.UseSubject,
+            CannyThresholdPercent = preset.CannyOptions?.Threshold is > 0 ? preset.CannyOptions.Threshold.Value : null,
+            SubjectMaskPadding = subjectMaskPadding,
+            UseInvertedSubjectMask = useInvertedSubjectMask,
+            SortByName = sortByName,
+            UseSubtractMasks = useSubtractMasks,
+            DirectionName = directionName
+        };
     }
 
     private static bool TryGetMappedValue(IReadOnlyDictionary<string, string>? map, string key, out string value)
@@ -182,10 +172,18 @@ public class PresetService : IPresetService
         return false;
     }
 
-    private static async Task<string> ReadAppPackageTextAsync(string path)
+    public async Task<TomlMap?> GetTomlMapAsync()
     {
-        using var stream = await FileSystem.OpenAppPackageFileAsync(path);
-        using var reader = new StreamReader(stream);
-        return await reader.ReadToEndAsync();
+        if (_cachedMap is not null)
+        {
+            return _cachedMap;
+        }
+
+        var mapContent = await BaseViewModel.ReadAppPackageTextAsync(TomlMapPath);
+        _cachedMap = JsonSerializer.Deserialize<TomlMap>(mapContent, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+        });
+        return _cachedMap;
     }
 }

--- a/PixelsorterApp/Services/TomlValidationService.cs
+++ b/PixelsorterApp/Services/TomlValidationService.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+using PixelsorterApp.Models.Presets;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using Tomlyn;
 using Tomlyn.Model;
@@ -7,7 +8,6 @@ namespace PixelsorterApp.Services
 {
     public sealed class TomlValidationService : ITomlValidationService
     {
-        private const string TomlMapPath = "presets/tomlMap.json";
         private readonly IImageProcessingService imageProcessingService;
 
         public TomlValidationService(IImageProcessingService imageProcessingService)
@@ -24,7 +24,7 @@ namespace PixelsorterApp.Services
         /// <param name="content">The TOML content to validate. This parameter cannot be null or empty.</param>
         /// <returns>A tuple containing a boolean that indicates whether the TOML content is valid, and a string with error
         /// messages if validation fails.</returns>
-        public async Task<(bool isValid, string errors)> Validate(string content)
+        public async Task<(bool isValid, string errors)> Validate(string content, TomlMap? map)
         {
 
             var errors = new List<string>();
@@ -34,8 +34,7 @@ namespace PixelsorterApp.Services
                 return (false, "TOML content is empty.");
             }
 
-            TomlMap? tomlMap = await LoadTomlMapAsync();
-            if (tomlMap is null)
+            if (map is null)
             {
                 return (false, "Failed to load toml map.");
             }
@@ -70,10 +69,10 @@ namespace PixelsorterApp.Services
             string whatToSort = GetString(subjectSettings, "what_to_sort", errors);
             string mode = GetString(maskCombination, "mode", errors);
 
-            ValidateMappedOption(sortBy, tomlMap.SortBy, "sort_settings.sort_by", errors);
-            ValidateMappedOption(direction, tomlMap.Direction, "sort_settings.direction", errors);
-            ValidateMappedOption(whatToSort, tomlMap.WhatToSort, "subject_settings.what_to_sort", errors);
-            ValidateMappedOption(mode, tomlMap.MaskCombination, "mask_combination.mode", errors);
+            ValidateMappedOption(sortBy, map.SortBy, "sort_settings.sort_by", errors);
+            ValidateMappedOption(direction, map.Direction, "sort_settings.direction", errors);
+            ValidateMappedOption(whatToSort, map.WhatToSort, "subject_settings.what_to_sort", errors);
+            ValidateMappedOption(mode, map.MaskCombination, "mask_combination.mode", errors);
 
             if (string.Equals(direction, "im", StringComparison.OrdinalIgnoreCase) && !useSubject && !useCanny)
             {
@@ -206,46 +205,19 @@ namespace PixelsorterApp.Services
         /// <param name="fieldName">The name of the field being validated. Used to identify the field in any generated error messages.</param>
         /// <param name="errors">A list to which error messages are added if validation fails. The method appends an error message if the
         /// value is not found in the mapping.</param>
-        private static void ValidateMappedOption(string value, Dictionary<string, string> map, string fieldName, List<string> errors)
+        private static void ValidateMappedOption(string value, Dictionary<string, string>? map, string fieldName, List<string> errors)
         {
             if (string.IsNullOrWhiteSpace(value))
             {
                 return;
             }
 
-            if (!map.ContainsKey(value))
+            if (map is null || !map.ContainsKey(value))
             {
                 errors.Add($"Invalid value for {fieldName}: '{value}'.");
             }
         }
 
-        private static async Task<TomlMap?> LoadTomlMapAsync()
-        {
-            try
-            {
-                using var stream = await FileSystem.OpenAppPackageFileAsync(TomlMapPath);
-                using var reader = new StreamReader(stream);
-                string content = await reader.ReadToEndAsync();
-
-                return JsonSerializer.Deserialize<TomlMap>(content, new JsonSerializerOptions
-                {
-                    PropertyNameCaseInsensitive = true
-                });
-            }
-            catch
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
-        /// Sanitizes the specified string by normalizing line endings and formatting mode declarations for consistency.
-        /// </summary>
-        /// <remarks>This method replaces all Windows-style line endings (\r\n) and carriage returns (\r)
-        /// with Unix-style line endings (\n). It also reformats lines declaring a mode so that they use the syntax 'mode
-        /// = "value"'.</remarks>
-        /// <param name="content">The input string to sanitize. May contain Windows-style line endings and unformatted mode declarations.</param>
-        /// <returns>A string with Unix-style line endings and consistently formatted mode declarations.</returns>
         public string Sanitize(string content)
         {
             content = content.Replace("\r\n", "\n").Replace('\r', '\n');
@@ -256,12 +228,6 @@ namespace PixelsorterApp.Services
             "mode = \"${value}\"");
         }
 
-        private sealed class TomlMap
-        {
-            public Dictionary<string, string> SortBy { get; set; } = [];
-            public Dictionary<string, string> Direction { get; set; } = [];
-            public Dictionary<string, string> MaskCombination { get; set; } = [];
-            public Dictionary<string, string> WhatToSort { get; set; } = [];
-        }
+
     }
 }

--- a/PixelsorterApp/Services/TomlValidationService.cs
+++ b/PixelsorterApp/Services/TomlValidationService.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics;
-using System.Text;
-using System.Text.Json;
+﻿using System.Text.Json;
 using System.Text.RegularExpressions;
 using Tomlyn;
 using Tomlyn.Model;
@@ -194,20 +192,20 @@ namespace PixelsorterApp.Services
             return 0;
         }
 
-       /// <summary>
-       /// Validates that the specified value exists as a key in the provided mapping and records an error if it does
-       /// not.
-       /// </summary>
-       /// <remarks>No validation is performed if the value is null or white space. This method is
-       /// typically used to validate user input or configuration values against a predefined set of allowed
-       /// options.</remarks>
-       /// <param name="value">The value to validate. This parameter is not validated if it is null or consists only of white-space
-       /// characters.</param>
-       /// <param name="map">A dictionary containing the set of valid values as keys. The method checks whether the specified value exists
-       /// in this dictionary.</param>
-       /// <param name="fieldName">The name of the field being validated. Used to identify the field in any generated error messages.</param>
-       /// <param name="errors">A list to which error messages are added if validation fails. The method appends an error message if the
-       /// value is not found in the mapping.</param>
+        /// <summary>
+        /// Validates that the specified value exists as a key in the provided mapping and records an error if it does
+        /// not.
+        /// </summary>
+        /// <remarks>No validation is performed if the value is null or white space. This method is
+        /// typically used to validate user input or configuration values against a predefined set of allowed
+        /// options.</remarks>
+        /// <param name="value">The value to validate. This parameter is not validated if it is null or consists only of white-space
+        /// characters.</param>
+        /// <param name="map">A dictionary containing the set of valid values as keys. The method checks whether the specified value exists
+        /// in this dictionary.</param>
+        /// <param name="fieldName">The name of the field being validated. Used to identify the field in any generated error messages.</param>
+        /// <param name="errors">A list to which error messages are added if validation fails. The method appends an error message if the
+        /// value is not found in the mapping.</param>
         private static void ValidateMappedOption(string value, Dictionary<string, string> map, string fieldName, List<string> errors)
         {
             if (string.IsNullOrWhiteSpace(value))
@@ -240,14 +238,14 @@ namespace PixelsorterApp.Services
             }
         }
 
-       /// <summary>
-       /// Sanitizes the specified string by normalizing line endings and formatting mode declarations for consistency.
-       /// </summary>
-       /// <remarks>This method replaces all Windows-style line endings (\r\n) and carriage returns (\r)
-       /// with Unix-style line endings (\n). It also reformats lines declaring a mode so that they use the syntax 'mode
-       /// = "value"'.</remarks>
-       /// <param name="content">The input string to sanitize. May contain Windows-style line endings and unformatted mode declarations.</param>
-       /// <returns>A string with Unix-style line endings and consistently formatted mode declarations.</returns>
+        /// <summary>
+        /// Sanitizes the specified string by normalizing line endings and formatting mode declarations for consistency.
+        /// </summary>
+        /// <remarks>This method replaces all Windows-style line endings (\r\n) and carriage returns (\r)
+        /// with Unix-style line endings (\n). It also reformats lines declaring a mode so that they use the syntax 'mode
+        /// = "value"'.</remarks>
+        /// <param name="content">The input string to sanitize. May contain Windows-style line endings and unformatted mode declarations.</param>
+        /// <returns>A string with Unix-style line endings and consistently formatted mode declarations.</returns>
         public string Sanitize(string content)
         {
             content = content.Replace("\r\n", "\n").Replace('\r', '\n');

--- a/PixelsorterApp/ViewModels/MainPageViewModel.cs
+++ b/PixelsorterApp/ViewModels/MainPageViewModel.cs
@@ -5,11 +5,7 @@ using PixelsorterClassLib.Core;
 using SixLabors.ImageSharp.ColorSpaces;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
-using Tomlyn;
-using Tomlyn.Serialization;
 
 namespace PixelsorterApp.ViewModels;
 

--- a/PixelsorterApp/ViewModels/MainPageViewModel.cs
+++ b/PixelsorterApp/ViewModels/MainPageViewModel.cs
@@ -543,7 +543,8 @@ public sealed partial class MainPageViewModel : BaseViewModel
 
         if (!string.IsNullOrEmpty(state.DirectionName))
         {
-            var directionIndex = SortDirectionOptions.IndexOf(state.DirectionName);
+            var displayName = Regex.Replace(state.DirectionName, "([A-Z])", " $1").Trim();
+            var directionIndex = SortDirectionOptions.IndexOf(displayName);
             if (directionIndex >= 0) SelectedSortDirectionIndex = directionIndex;
         }
     }

--- a/PixelsorterApp/ViewModels/MainPageViewModel.cs
+++ b/PixelsorterApp/ViewModels/MainPageViewModel.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using PixelsorterApp.Services;
+using PixelsorterApp.Models.Presets;
 using PixelsorterClassLib.Core;
 using SixLabors.ImageSharp.ColorSpaces;
 using System.Collections.ObjectModel;
@@ -15,9 +16,6 @@ namespace PixelsorterApp.ViewModels;
 public sealed partial class MainPageViewModel : BaseViewModel
 {
     private readonly IPresetService presetService;
-
-
-
     private readonly IHelpNavigationService helpNavigationService;
     private readonly IPresetNavigationService presetNavigationService;
     private readonly Dictionary<string, Func<Hsl, float>> sortByOptions = SortBy.GetAllSortingCriteria();
@@ -25,6 +23,7 @@ public sealed partial class MainPageViewModel : BaseViewModel
     private IReadOnlyDictionary<string, string> AvailablePresets = new Dictionary<string, string>();
     private const string NewPresetOptionLabel = "new preset";
     private bool suppressPresetSelectionChangedHandling;
+    private bool suppressSortDirectionRefresh;
     private bool isNavigatingToPresetPage;
     private string? lastValidPresetOption;
 
@@ -360,6 +359,11 @@ public sealed partial class MainPageViewModel : BaseViewModel
     /// </summary>
     private void RefreshSortDirectionOptions()
     {
+        if (suppressSortDirectionRefresh)
+        {
+            return;
+        }
+
         string? previousSelection =
             SelectedSortDirectionIndex >= 0 && SelectedSortDirectionIndex < SortDirectionOptions.Count
                 ? SortDirectionOptions[SelectedSortDirectionIndex]
@@ -520,14 +524,23 @@ public sealed partial class MainPageViewModel : BaseViewModel
         }
     }
 
-    private void ApplyPresetState(PixelsorterApp.Models.Presets.PresetState state)
+    private void ApplyPresetState(PresetState state)
     {
-        if (state.UseCanny.HasValue) UseCanny = state.UseCanny.Value;
-        if (state.UseSubjectMask.HasValue) UseSubjectMask = state.UseSubjectMask.Value;
-        if (state.CannyThresholdPercent.HasValue) CannyThresholdPercent = state.CannyThresholdPercent.Value;
-        if (state.SubjectMaskPadding.HasValue) SubjectMaskPadding = state.SubjectMaskPadding.Value;
-        if (state.UseInvertedSubjectMask.HasValue) UseInvertedSubjectMask = state.UseInvertedSubjectMask.Value;
-        if (state.UseSubtractMasks.HasValue) UseSubtractMasks = state.UseSubtractMasks.Value;
+        suppressSortDirectionRefresh = true;
+        try
+        {
+            if (state.UseCanny.HasValue) UseCanny = state.UseCanny.Value;
+            if (state.UseSubjectMask.HasValue) UseSubjectMask = state.UseSubjectMask.Value;
+            if (state.CannyThresholdPercent.HasValue) CannyThresholdPercent = state.CannyThresholdPercent.Value;
+            if (state.SubjectMaskPadding.HasValue) SubjectMaskPadding = state.SubjectMaskPadding.Value;
+            if (state.UseInvertedSubjectMask.HasValue) UseInvertedSubjectMask = state.UseInvertedSubjectMask.Value;
+            if (state.UseSubtractMasks.HasValue) UseSubtractMasks = state.UseSubtractMasks.Value;
+        }
+        finally
+        {
+            suppressSortDirectionRefresh = false;
+            RefreshSortDirectionOptions();
+        }
 
         if (!string.IsNullOrEmpty(state.SortByName))
         {

--- a/PixelsorterApp/ViewModels/MainPageViewModel.cs
+++ b/PixelsorterApp/ViewModels/MainPageViewModel.cs
@@ -18,12 +18,7 @@ namespace PixelsorterApp.ViewModels;
 /// </summary>
 public sealed partial class MainPageViewModel : BaseViewModel
 {
-    private readonly ITomlValidationService tomlValidationService;
-
-    private readonly string defaultPresetPreference = Preferences.Get("defaultPreset", "base.toml");
-    private readonly string BasePresetPath = "presets/" + "base.toml";
-    private readonly string UserPresetsPath = Path.Combine(FileSystem.Current.AppDataDirectory, "Presets");
-    public const string TomlMapPath = "presets/tomlMap.json";
+    private readonly IPresetService presetService;
 
 
 
@@ -31,7 +26,7 @@ public sealed partial class MainPageViewModel : BaseViewModel
     private readonly IPresetNavigationService presetNavigationService;
     private readonly Dictionary<string, Func<Hsl, float>> sortByOptions = SortBy.GetAllSortingCriteria();
     private readonly Dictionary<string, SortDirections> sortDirectionOptions = [];
-    private readonly Dictionary<string, string> AvailablePresets = [];
+    private IReadOnlyDictionary<string, string> AvailablePresets = new Dictionary<string, string>();
     private const string NewPresetOptionLabel = "new preset";
     private bool suppressPresetSelectionChangedHandling;
     private bool isNavigatingToPresetPage;
@@ -148,11 +143,11 @@ public sealed partial class MainPageViewModel : BaseViewModel
     /// <summary>
     /// Initializes a new instance of the <see cref="MainPageViewModel"/> class.
     /// </summary>
-    public MainPageViewModel(IHelpNavigationService helpNavigationService, IPresetNavigationService presetNavigationService, ITomlValidationService tomlValidationService)
+    public MainPageViewModel(IHelpNavigationService helpNavigationService, IPresetNavigationService presetNavigationService, IPresetService presetService)
     {
         this.helpNavigationService = helpNavigationService;
         this.presetNavigationService = presetNavigationService;
-        this.tomlValidationService = tomlValidationService;
+        this.presetService = presetService;
 
         sortCommand = new RelayCommand(() => SortRequested?.Invoke(), () => IsSortEnabled);
         saveCommand = new RelayCommand(() => SaveRequested?.Invoke(), () => IsSaveEnabled);
@@ -170,9 +165,20 @@ public sealed partial class MainPageViewModel : BaseViewModel
         RefreshSortDirectionOptions();
         SelectedSortDirectionIndex = SortDirectionOptions.Count > 0 ? 0 : -1;
 
-        GetAvailablePresets();
-        SelectedPresetOption = FindDefaultPresetOption() ?? PresetOptions.FirstOrDefault();
+        RefreshAvailablePresets();
+        SelectedPresetOption = this.presetService.FindDefaultPresetOption(AvailablePresets) ?? PresetOptions.FirstOrDefault();
         lastValidPresetOption = SelectedPresetOption;
+    }
+
+    public void RefreshAvailablePresets()
+    {
+        AvailablePresets = this.presetService.GetAvailablePresets();
+        PresetOptions.Clear();
+        foreach (var presetName in AvailablePresets.Keys)
+        {
+            PresetOptions.Add(presetName);
+        }
+        PresetOptions.Add(NewPresetOptionLabel);
     }
 
     /// <summary>
@@ -392,359 +398,6 @@ public sealed partial class MainPageViewModel : BaseViewModel
         }
     }
 
-    /// <summary>
-    /// Populates the list of available presets and preset options by scanning the base and user preset directories.
-    /// </summary>
-    /// <remarks>This method clears and repopulates the collections that track available presets and their
-    /// display options. It adds the base preset and any user-defined presets found in the specified directory. A
-    /// special option for creating a new preset is also appended to the options list. Call this method to refresh the
-    /// preset lists after changes to the preset files.</remarks>
-    public void GetAvailablePresets()
-    {
-        try
-        {
-            AvailablePresets.Clear();
-            PresetOptions.Clear();
-
-            AvailablePresets.Add("Base", BasePresetPath);
-            if (Directory.Exists(UserPresetsPath))
-            {
-                var files = Directory.GetFiles(UserPresetsPath, "*.toml");
-                foreach (var file in files)
-                {
-                    AvailablePresets[Path.GetFileNameWithoutExtension(file)] = file;
-                }
-            }
-
-            foreach (var presetName in AvailablePresets.Keys)
-            {
-                PresetOptions.Add(presetName);
-            }
-
-            PresetOptions.Add("new preset");
-        }
-        catch (Exception ex)
-        {
-            System.Diagnostics.Debug.WriteLine($"Error loading presets: {ex}");
-        }
-    }
-
-    /// <summary>
-    /// Finds the key of the preset that matches the default preset preference, using case-insensitive comparison on
-    /// both keys and values.
-    /// </summary>
-    /// <remarks>The method compares the default preset preference against both the keys and values of
-    /// available presets, as well as the file name portion of each preset value. This allows for flexible matching
-    /// based on either the full path or just the file name.</remarks>
-    /// <returns>The key of the matching preset if found; otherwise, null.</returns>
-    private string? FindDefaultPresetOption()
-    {
-        string normalizedDefaultPreset = Path.GetFileName(defaultPresetPreference);
-
-        foreach (var preset in AvailablePresets)
-        {
-            if (string.Equals(preset.Key, defaultPresetPreference, StringComparison.OrdinalIgnoreCase)
-                || string.Equals(preset.Value, defaultPresetPreference, StringComparison.OrdinalIgnoreCase)
-                || string.Equals(Path.GetFileName(preset.Value), normalizedDefaultPreset, StringComparison.OrdinalIgnoreCase))
-            {
-                return preset.Key;
-            }
-        }
-
-        return null;
-    }
-
-    /// <summary>
-    /// Asynchronously loads a preset from the specified path and applies it using the associated TOML map.
-    /// </summary>
-    /// <remarks>If the specified preset path is not rooted, the method attempts to read the file from the
-    /// application package. The method silently ignores errors that occur during loading or deserialization.</remarks>
-    /// <param name="presetPath">The path to the preset file to load. Can be an absolute file system path or a relative path within the
-    /// application package.</param>
-    /// <returns>A task that represents the asynchronous load operation.</returns>
-    private async Task LoadPresetAsync(string presetPath)
-    {
-        try
-        {
-            var tomlContent = Path.IsPathRooted(presetPath)
-                ? await File.ReadAllTextAsync(presetPath)
-                : await ReadAppPackageTextAsync(presetPath);
-            var mapContent = await ReadAppPackageTextAsync(TomlMapPath);
-
-            var map = JsonSerializer.Deserialize<TomlMap>(mapContent, new JsonSerializerOptions
-            {
-                PropertyNameCaseInsensitive = true,
-            });
-
-            if (map is null)
-            {
-                return;
-            }
-
-            ApplyPreset(tomlContent, map);
-        }
-        catch
-        {
-        }
-    }
-
-    
-
-    /// <summary>
-    /// Applies the settings from a TOML-formatted preset to the current configuration using the specified mapping.
-    /// </summary>
-    /// <remarks>If the TOML content is invalid or does not contain applicable settings, no changes are made.
-    /// Only recognized and valid preset options are applied to the current configuration.</remarks>
-    /// <param name="tomlContent">The TOML-formatted string containing the preset settings to apply. Cannot be null or empty.</param>
-    /// <param name="map">A mapping object that defines how preset values are translated to internal configuration options. Cannot be
-    /// null.</param>
-    private void ApplyPreset(string tomlContent, TomlMap map)
-    {
-        var sanitizedToml = tomlValidationService.Sanitize(tomlContent);
-
-
-        if (!TomlSerializer.TryDeserialize(sanitizedToml, out PresetToml? preset, null) || preset is null)
-        {
-            return;
-        }
-
-        if (preset.MaskingOptions is not null)
-        {
-            UseCanny = preset.MaskingOptions.UseCanny;
-            UseSubjectMask = preset.MaskingOptions.UseSubject;
-        }
-
-        if (preset.CannyOptions is not null)
-        {
-            var threshold = preset.CannyOptions.Threshold;
-            if (threshold is > 0)
-            {
-                CannyThresholdPercent = threshold.Value;
-            }
-        }
-
-        if (preset.SubjectSettings is not null)
-        {
-            if (preset.SubjectSettings.Padding is > 0)
-            {
-                SubjectMaskPadding = preset.SubjectSettings.Padding.Value;
-            }
-
-            if (!string.IsNullOrWhiteSpace(preset.SubjectSettings.WhatToSort))
-            {
-                if (TryGetMappedValue(map.WhatToSort, preset.SubjectSettings.WhatToSort, out var whatToSortMapped))
-                {
-                    UseInvertedSubjectMask = string.Equals(
-                        whatToSortMapped,
-                        nameof(SortForegroundSelected),
-                        StringComparison.Ordinal);
-                }
-                else
-                {
-                    UseInvertedSubjectMask = string.Equals(preset.SubjectSettings.WhatToSort, "foreground", StringComparison.OrdinalIgnoreCase);
-                }
-            }
-        }
-
-        if (!string.IsNullOrWhiteSpace(preset.SortSettings?.SortBy)
-            && TryGetMappedValue(map.SortBy, preset.SortSettings.SortBy, out var sortByMapped))
-        {
-            var sortByName = sortByMapped.Split('.').Last();
-            var sortByIndex = FindIndex(SortByOptions, sortByName);
-            if (sortByIndex >= 0)
-            {
-                SelectedSortByIndex = sortByIndex;
-            }
-        }
-
-        if (!string.IsNullOrWhiteSpace(preset.MaskCombination?.Mode)
-            && TryGetMappedValue(map.MaskCombination, preset.MaskCombination.Mode, out var maskCombinationMapped))
-        {
-            UseSubtractMasks = string.Equals(
-                maskCombinationMapped,
-                nameof(UseSubtractMasksSelected),
-                StringComparison.Ordinal);
-        }
-
-        if (!string.IsNullOrWhiteSpace(preset.SortSettings?.Direction)
-            && TryGetMappedValue(map.Direction, preset.SortSettings.Direction, out var directionMapped)
-            && Enum.TryParse<SortDirections>(directionMapped.Split('.').Last(), out var direction))
-        {
-            var directionName = sortDirectionOptions
-                .FirstOrDefault(option => option.Value == direction)
-                .Key;
-
-            if (!string.IsNullOrWhiteSpace(directionName))
-            {
-                var directionIndex = SortDirectionOptions.IndexOf(directionName);
-                if (directionIndex >= 0)
-                {
-                    SelectedSortDirectionIndex = directionIndex;
-                }
-            }
-        }
-    }
-
-    /// <summary>
-    /// Searches for the specified string and returns the zero-based index of its first occurrence in the given
-    /// read-only list.
-    /// </summary>
-    /// <param name="items">The read-only list of strings to search.</param>
-    /// <param name="value">The string value to locate in the list. The comparison is case-sensitive and uses ordinal comparison.</param>
-    /// <returns>The zero-based index of the first occurrence of the specified value in the list; otherwise, -1 if the value is
-    /// not found.</returns>
-    private static int FindIndex(IReadOnlyList<string> items, string value)
-    {
-        for (var i = 0; i < items.Count; i++)
-        {
-            if (string.Equals(items[i], value, StringComparison.Ordinal))
-            {
-                return i;
-            }
-        }
-
-        return -1;
-    }
-
-    /// <summary>
-    /// Attempts to retrieve the value associated with the specified key from the provided dictionary, using a
-    /// case-insensitive key comparison.
-    /// </summary>
-    /// <remarks>If the dictionary is null or does not contain the specified key, the method returns false and
-    /// the out parameter is set to an empty string. Key comparison is performed using ordinal, case-insensitive
-    /// matching.</remarks>
-    /// <param name="map">The dictionary to search for the specified key. Can be null.</param>
-    /// <param name="key">The key to locate in the dictionary. The comparison is case-insensitive.</param>
-    /// <param name="value">When this method returns, contains the value associated with the specified key if the key is found; otherwise,
-    /// an empty string.</param>
-    /// <returns>true if the dictionary contains an entry with the specified key; otherwise, false.</returns>
-    private static bool TryGetMappedValue(IReadOnlyDictionary<string, string>? map, string key, out string value)
-    {
-        value = string.Empty;
-
-        if (map is null)
-        {
-            return false;
-        }
-
-        foreach (var pair in map)
-        {
-            if (string.Equals(pair.Key, key, StringComparison.OrdinalIgnoreCase))
-            {
-                value = pair.Value;
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /// <summary>
-    /// Represents a collection of TOML mapping configurations for sorting and masking operations.
-    /// </summary>
-    /// <remarks>This class is used to deserialize TOML configuration sections related to sorting and masking.
-    /// Each property corresponds to a specific mapping, where the key is typically a field or identifier and the value
-    /// specifies the associated configuration. All properties are read-only after initialization.</remarks>
-    private sealed class TomlMap
-    {
-        [JsonPropertyName("sortBy")]
-        public Dictionary<string, string>? SortBy { get; init; }
-
-        [JsonPropertyName("direction")]
-        public Dictionary<string, string>? Direction { get; init; }
-
-        [JsonPropertyName("maskCombination")]
-        public Dictionary<string, string>? MaskCombination { get; init; }
-
-        [JsonPropertyName("whatToSort")]
-        public Dictionary<string, string>? WhatToSort { get; init; }
-    }
-
-    /// <summary>
-    /// Represents a deserialized TOML preset containing configuration options for sorting, masking, edge detection,
-    /// subject settings, and mask combination.
-    /// </summary>
-    /// <remarks>This class is used to map TOML configuration files to strongly typed objects for use within
-    /// the application. Each property corresponds to a specific section in the TOML file and may be null if not
-    /// specified in the configuration.</remarks>
-    private sealed class PresetToml
-    {
-        [TomlPropertyName("sort_settings")]
-        public SortSettings? SortSettings { get; init; }
-
-        [TomlPropertyName("masking_options")]
-        public MaskingOptions? MaskingOptions { get; init; }
-
-        [TomlPropertyName("canny_options")]
-        public CannyOptions? CannyOptions { get; init; }
-
-        [TomlPropertyName("subject_settings")]
-        public SubjectSettings? SubjectSettings { get; init; }
-
-        [TomlPropertyName("mask_combination")]
-        public MaskCombination? MaskCombination { get; init; }
-    }
-
-    /// <summary>
-    /// Represents the configuration settings for sorting, including the property to sort by and the sort direction.
-    /// </summary>
-    private sealed class SortSettings
-    {
-        [TomlPropertyName("sort_by")]
-        public string? SortBy { get; init; }
-
-        [TomlPropertyName("direction")]
-        public string? Direction { get; init; }
-    }
-
-    /// <summary>
-    /// Represents configuration options for controlling masking behavior in image processing operations.
-    /// </summary>
-    /// <remarks>This class encapsulates settings that determine which masking techniques are applied, such as
-    /// Canny edge detection or subject-based masking. It is intended to be used as a container for related masking
-    /// flags when configuring processing pipelines.</remarks>
-    private sealed class MaskingOptions
-    {
-        [TomlPropertyName("use_canny")]
-        public bool UseCanny { get; init; }
-
-        [TomlPropertyName("use_subject")]
-        public bool UseSubject { get; init; }
-    }
-
-    
-    /// <summary>
-    /// Represents configuration options for the Canny edge detection algorithm.
-    /// </summary>
-    /// <remarks>This class encapsulates parameters that control the behavior of the Canny algorithm, such as
-    /// the edge detection threshold. It is intended to be used as a container for algorithm settings when processing
-    /// images.</remarks>
-    private sealed class CannyOptions
-    {
-        [TomlPropertyName("threshold")]
-        public int? Threshold { get; init; }
-    }
-
-    /// <summary>
-    /// Represents configuration options for subject-based masking.
-    /// </summary>
-    private sealed class SubjectSettings
-    {
-        [TomlPropertyName("padding")]
-        public int? Padding { get; init; }
-
-        [TomlPropertyName("what_to_sort")]
-        public string? WhatToSort { get; init; }
-    }
-
-    /// <summary>
-    /// Represents a combination of masks used for configuration settings.
-    /// </summary>
-    private sealed class MaskCombination
-    {
-        [TomlPropertyName("mode")]
-        public string? Mode { get; init; }
-    }
 
     partial void OnUseSubjectMaskChanged(bool value)
     {
@@ -864,6 +517,38 @@ public sealed partial class MainPageViewModel : BaseViewModel
         }
 
         lastValidPresetOption = value;
-        await LoadPresetAsync(presetPath);
+        var presetState = await this.presetService.LoadPresetAsync(presetPath);
+        if (presetState != null)
+        {
+            ApplyPresetState(presetState);
+        }
+    }
+
+    private void ApplyPresetState(PixelsorterApp.Models.Presets.PresetState state)
+    {
+        if (state.UseCanny.HasValue) UseCanny = state.UseCanny.Value;
+        if (state.UseSubjectMask.HasValue) UseSubjectMask = state.UseSubjectMask.Value;
+        if (state.CannyThresholdPercent.HasValue) CannyThresholdPercent = state.CannyThresholdPercent.Value;
+        if (state.SubjectMaskPadding.HasValue) SubjectMaskPadding = state.SubjectMaskPadding.Value;
+        if (state.UseInvertedSubjectMask.HasValue) UseInvertedSubjectMask = state.UseInvertedSubjectMask.Value;
+        if (state.UseSubtractMasks.HasValue) UseSubtractMasks = state.UseSubtractMasks.Value;
+
+        if (!string.IsNullOrEmpty(state.SortByName))
+        {
+            for (int i = 0; i < SortByOptions.Count; i++)
+            {
+                if (string.Equals(SortByOptions[i], state.SortByName, StringComparison.Ordinal))
+                {
+                    SelectedSortByIndex = i;
+                    break;
+                }
+            }
+        }
+
+        if (!string.IsNullOrEmpty(state.DirectionName))
+        {
+            var directionIndex = SortDirectionOptions.IndexOf(state.DirectionName);
+            if (directionIndex >= 0) SelectedSortDirectionIndex = directionIndex;
+        }
     }
 }

--- a/PixelsorterApp/ViewModels/PresetsPageViewModel.cs
+++ b/PixelsorterApp/ViewModels/PresetsPageViewModel.cs
@@ -1,4 +1,4 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using PixelsorterApp.Services;
 using System.Collections.ObjectModel;
@@ -119,7 +119,7 @@ namespace PixelsorterApp.ViewModels
 
             subtractMask = _mainViewModel.UseSubtractMasks;
 
-            tomlMapPath = MainPageViewModel.TomlMapPath;
+            tomlMapPath = "presets/tomlMap.json";
             tomlMap = Task.Run(() => LoadTomlMap()).GetAwaiter().GetResult();
             TomlMapString = FormatTomlMap(tomlMap);
 
@@ -183,7 +183,7 @@ namespace PixelsorterApp.ViewModels
                 {
                     Preferences.Set("defaultPreset", fileName);
                 }
-                _mainViewModel.GetAvailablePresets();
+                _mainViewModel.RefreshAvailablePresets();
                 RefreshAvailablePresets();
                 _mainViewModel.SelectedPresetOption = presetName;
             }
@@ -288,7 +288,7 @@ namespace PixelsorterApp.ViewModels
             }
 
             await DeletePresetFileAsync(preset.Name);
-            _mainViewModel.GetAvailablePresets();
+            _mainViewModel.RefreshAvailablePresets();
             RefreshAvailablePresets();
             SavePresetValidationMessage = $"Deleted preset '{preset.Name}'.";
         }

--- a/PixelsorterApp/ViewModels/PresetsPageViewModel.cs
+++ b/PixelsorterApp/ViewModels/PresetsPageViewModel.cs
@@ -30,7 +30,7 @@ namespace PixelsorterApp.ViewModels
         private readonly TomlMap? tomlMap;
 
         [ObservableProperty]
-        public partial string PresetToml {  get; set; }
+        public partial string PresetToml { get; set; }
 
         [ObservableProperty]
         public partial string TomlMapString { get; set; }

--- a/PixelsorterApp/ViewModels/PresetsPageViewModel.cs
+++ b/PixelsorterApp/ViewModels/PresetsPageViewModel.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using PixelsorterApp.Services;
+using PixelsorterApp.Models.Presets;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Text;
@@ -24,8 +25,6 @@ namespace PixelsorterApp.ViewModels
         private readonly string UserPresetsPath = Path.Combine(FileSystem.Current.AppDataDirectory, "Presets");
 
         private readonly bool subtractMask;
-
-        private readonly string tomlMapPath;
 
         private readonly TomlMap? tomlMap;
 
@@ -99,10 +98,10 @@ namespace PixelsorterApp.ViewModels
             SavePresetValidationMessage = "Base preset set as default.";
         }
 
-        public ObservableCollection<PresetListItem> AvilablePresets { get; set; }
+        public ObservableCollection<PresetListItem> AvailablePresets { get; set; }
 
 
-        public PresetsPageViewModel(MainPageViewModel mainViewModel, ITomlValidationService tomlValidationService)
+        public PresetsPageViewModel(MainPageViewModel mainViewModel, ITomlValidationService tomlValidationService, IPresetService presetService)
         {
             _mainViewModel = mainViewModel;
             this.tomlValidationService = tomlValidationService;
@@ -119,8 +118,7 @@ namespace PixelsorterApp.ViewModels
 
             subtractMask = _mainViewModel.UseSubtractMasks;
 
-            tomlMapPath = "presets/tomlMap.json";
-            tomlMap = Task.Run(() => LoadTomlMap()).GetAwaiter().GetResult();
+            tomlMap = Task.Run(() => presetService.GetTomlMapAsync()).GetAwaiter().GetResult();
             TomlMapString = FormatTomlMap(tomlMap);
 
             PresetToml = CreateToml();
@@ -128,7 +126,7 @@ namespace PixelsorterApp.ViewModels
 
             PresetName = $"Preset {_mainViewModel.PresetOptions.Count}";
 
-            AvilablePresets = new ObservableCollection<PresetListItem>();
+            AvailablePresets = new ObservableCollection<PresetListItem>();
             RefreshAvailablePresets();
 
         }
@@ -143,7 +141,7 @@ namespace PixelsorterApp.ViewModels
         private async Task<bool> ValidatePresetAsync()
         {
             PresetToml = tomlValidationService.Sanitize(PresetToml);
-            (bool isValid, string errors) = await tomlValidationService.Validate(PresetToml);
+            (bool isValid, string errors) = await tomlValidationService.Validate(PresetToml, tomlMap);
 
             SavePresetValidationMessage = isValid
                 ? "TOML is valid."
@@ -383,33 +381,6 @@ namespace PixelsorterApp.ViewModels
         }
 
         /// <summary>
-        /// Loads the TOML map from a JSON file located at the path specified by 'tomlMapPath'. 
-        /// The method attempts to read the file, deserialize its content into a TomlMap object, and return it. 
-        /// If any error occurs during this process (e.g., file not found, invalid JSON), 
-        /// the method catches the exception and returns null, indicating that the TOML map could not be loaded 
-        /// successfully.
-        /// </summary>
-        /// <returns>The loaded TOML map, or null if loading failed.</returns>
-        private async Task<TomlMap?> LoadTomlMap()
-        {
-            try
-            {
-                using Stream stream = await FileSystem.OpenAppPackageFileAsync(tomlMapPath);
-                using StreamReader reader = new(stream);
-                string content = await reader.ReadToEndAsync();
-
-                return JsonSerializer.Deserialize<TomlMap>(content, new JsonSerializerOptions
-                {
-                    PropertyNameCaseInsensitive = true
-                });
-            }
-            catch
-            {
-                return null;
-            }
-        }
-
-        /// <summary>
         /// Retrieves the key from the specified map whose mapped value matches the provided selected value after
         /// normalization. Returns a fallback value if no matching key is found or if the map is null.
         /// </summary>
@@ -500,7 +471,7 @@ namespace PixelsorterApp.ViewModels
 
         private void RefreshAvailablePresets()
         {
-            AvilablePresets.Clear();
+            AvailablePresets.Clear();
             foreach (string preset in _mainViewModel.PresetOptions)
             {
                 if (string.Equals(preset, "new preset", StringComparison.OrdinalIgnoreCase)
@@ -509,35 +480,13 @@ namespace PixelsorterApp.ViewModels
                     continue;
                 }
 
-                AvilablePresets.Add(new PresetListItem { Name = preset });
+                AvailablePresets.Add(new PresetListItem { Name = preset });
             }
         }
 
         public sealed class PresetListItem
         {
             public required string Name { get; init; }
-        }
-
-        /// <summary>
-        /// Represents a collection of sorting and filtering criteria for TOML data.
-        /// </summary>
-        /// <remarks>The TomlMap class encapsulates parameters that define how TOML data should be sorted
-        /// and filtered. Each property is a dictionary that allows specifying flexible key-value pairs for sorting
-        /// fields, directions, mask combinations, and target elements. This class is typically used for deserializing
-        /// TOML configuration data that controls sorting and filtering behavior in an application.</remarks>
-        private sealed class TomlMap
-        {
-            [JsonPropertyName("sortBy")]
-            public Dictionary<string, string>? SortBy { get; set; }
-
-            [JsonPropertyName("direction")]
-            public Dictionary<string, string>? Direction { get; set; }
-
-            [JsonPropertyName("maskCombination")]
-            public Dictionary<string, string>? MaskCombination { get; set; }
-
-            [JsonPropertyName("whatToSort")]
-            public Dictionary<string, string>? WhatToSort { get; set; }
         }
 
         private async Task LoadPresetTomlFromFileAsync(string presetName)


### PR DESCRIPTION
## Description
This pull request significantly refactors the preset management system by extracting its responsibilities out of `MainPageViewModel` and into a dedicated `IPresetService`. By isolating file I/O, TOML/JSON deserialization, and preset state mapping, this PR drops over 350 lines of complex logic from the main view model, drastically improving testability, modularity, and adherence to the Single Responsibility Principle.

In addition to the architectural overhaul, this PR fixes multiple regressions related to preset loading and resolves underlying design issues (such as redundant static file reads and duplicate configuration maps).

### Key Changes

#### Architecture & Refactoring
- **New `IPresetService`**: Created a centralized service (`PresetService`) to handle preset discovery, loading, and parsing. 
- **DTOs Introduced**: Added `PresetModels.cs` and an immutable `PresetState.cs` to handle data transfer between the TOML parsing layer and the view models cleanly.
- **Dependency Injection**: Registered `IPresetService` as a singleton in `MauiProgram.cs` and injected it into `MainPageViewModel` and `PresetsPageViewModel`.
- **DRY Improvements**: 
  - Centralized the `TomlMap` loading in `IPresetService` and removed three redundant private `TomlMap` class definitions across the codebase.
  - Eliminated duplicated internal implementations of `ReadAppPackageTextAsync` in favor of reusing the existing utility in `BaseViewModel`.
  - Updated `ITomlValidationService` to accept a cached configuration map rather than loading its own instance from the disk.

#### Bug Fixes
- **UI Refresh Over-triggering**: Fixed a race condition/clobbering issue by temporarily suppressing `RefreshSortDirectionOptions()` while `ApplyPresetState` loops over and updates the individual state properties.

#### Chores & Cleanup
- Fixed XAML binding typo (`AvilablePresets` -> `AvailablePresets`).
- Enforced immutability via `init` properties on state models.
- Cleaned up unused imports and removed overly-verbose fully qualified namespaces.

## Related Issue
None

## 🍎 Apple Platform Testing
<!-- IMPORTANT: The maintainer DOES NOT own an Apple device. If your changes affect iOS or MacCatalyst, you MUST test them yourself and provide proof of functionality. -->
- [x] My changes do NOT affect iOS or MacCatalyst.
- [ ] My changes affect iOS/MacCatalyst, and I have tested them thoroughly on a device/simulator. 
<!-- If you checked the second box, please attach screenshots, screen recordings, or describe your testing process below: -->


## Checklist:
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have built the solution and verified that it complies successfully.
- [x] I have tested my changes on Windows and/or Android (or they are platform-agnostic).
- [x] I have adhered to the existing UI styling (e.g., flat layouts, non-editable looking pickers, visually distinct disabled buttons).
- [x] My changes generate no new warnings.
