### PR TITLE
Image picker

### DIFF
--- a/PixelsorterApp/Pages/MainPage.xaml.cs
+++ b/PixelsorterApp/Pages/MainPage.xaml.cs
@@ -250,9 +250,13 @@ namespace PixelsorterApp
         /// paths, and updates the user interface to reflect the newly loaded image. It also sets the appropriate UI
         /// elements to indicate that a new image is ready for further actions such as sorting.</remarks>
         /// <param name="path">The file path of the image to load. This must be a valid path to an image file.</param>
-        private void LoadImageFromPath(string path)
+        private Task<Boolean> LoadImageFromPath(string path)
         {
             this.imagePath = path;
+            if (Path.GetExtension(path) is ".dng" or ".nef" or ".cr2" or ".arw" or ".rw2" or ".orf")
+            {
+                return Task.FromResult(false);
+            }
             imageCaptions.Clear();
             imagePaths.Clear();
             imageCaptions.Add("Original image");
@@ -275,6 +279,7 @@ namespace PixelsorterApp
                 viewModel.IsSaveEnabled = false;
                 SemanticScreenReader.Announce("Image loaded. Ready to sort.");
             });
+            return Task.FromResult(true);
         }
 
         /// <summary>
@@ -350,7 +355,12 @@ namespace PixelsorterApp
         private async Task LoadImageAsync()
         {
             var results = await MediaPicker.PickPhotosAsync();
-            LoadImageFromPath(results[0].FullPath);       
+            var success = LoadImageFromPath(results[0].FullPath);
+            if (!success.Result)
+            {
+                await DisplayAlertAsync("Unsupported File Type", "The app doens't support raw images.", "OK");
+                await LoadImageAsync();
+            }
         }
 
         private string? sortedImagePath; // Path to the temporarily saved sorted image

--- a/PixelsorterApp/Pages/MainPage.xaml.cs
+++ b/PixelsorterApp/Pages/MainPage.xaml.cs
@@ -350,12 +350,7 @@ namespace PixelsorterApp
         private async Task LoadImageAsync()
         {
             var results = await MediaPicker.PickPhotosAsync();
-
-            foreach (var file in results)
-            {
-                LoadImageFromPath(file.FullPath);
-                break;
-            }
+            LoadImageFromPath(results[0].FullPath);       
         }
 
         private string? sortedImagePath; // Path to the temporarily saved sorted image

--- a/PixelsorterApp/Platforms/Android/MainActivity.cs
+++ b/PixelsorterApp/Platforms/Android/MainActivity.cs
@@ -51,6 +51,14 @@ namespace PixelsorterApp
             {
                 if (intent.Type.StartsWith("image/"))
                 {
+                    if (intent.Type == "image/x-adobe-dng")
+                    {
+                        // Use the global Application Context to show the Android Toast
+                        Android.Widget.Toast.MakeText(Android.App.Application.Context, "RAW Images (DNG) are not supported.", Android.Widget.ToastLength.Short)?.Show();
+
+                        // Make sure to return so you don't continue trying to process the unsupported file
+                        return;
+                    }
                     // Get the URI of the shared image
                     if (intent.GetParcelableExtra(Android.Content.Intent.ExtraStream, Java.Lang.Class.FromType(typeof(Android.Net.Uri))) is Android.Net.Uri imageUri)
                     {

--- a/PixelsorterApp/Platforms/Android/MainActivity.cs
+++ b/PixelsorterApp/Platforms/Android/MainActivity.cs
@@ -54,7 +54,7 @@ namespace PixelsorterApp
                     if (intent.Type == "image/x-adobe-dng")
                     {
                         // Use the global Application Context to show the Android Toast
-                        Android.Widget.Toast.MakeText(Android.App.Application.Context, "RAW Images (DNG) are not supported.", Android.Widget.ToastLength.Short)?.Show();
+                        Android.Widget.Toast.MakeText(Android.App.Application.Context, "RAW Images (DNG) are not supported.", Android.Widget.ToastLength.Long)?.Show();
 
                         // Make sure to return so you don't continue trying to process the unsupported file
                         return;


### PR DESCRIPTION
## Description
Raw images now can't be loaded anymore as they cause issues.
1. Picking an raw image via the image picker reopens the picker with an error message
2. Sending an raw image to the app on android shows an error message.

Targeting rededing branch because the error message needs that too.

## Related Issue
#47 

## 🍎 Apple Platform Testing
<!-- IMPORTANT: The maintainer DOES NOT own an Apple device. If your changes affect iOS or MacCatalyst, you MUST test them yourself and provide proof of functionality. -->
- [ ] My changes do NOT affect iOS or MacCatalyst.
- [x] My changes affect iOS/MacCatalyst, and I have tested them thoroughly on a device/simulator. 
<!-- If you checked the second box, please attach screenshots, screen recordings, or describe your testing process below: -->


## Checklist:
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have built the solution and verified that it complies successfully.
- [x] I have tested my changes on Windows and/or Android (or they are platform-agnostic).
- [x] I have adhered to the existing UI styling (e.g., flat layouts, non-editable looking pickers, visually distinct disabled buttons).
- [x] My changes generate no new warnings.
