### PR TITLE
Haptic feedback

### DIFF
--- a/PixelsorterApp/Pages/MainPage.xaml.cs
+++ b/PixelsorterApp/Pages/MainPage.xaml.cs
@@ -359,6 +359,7 @@ namespace PixelsorterApp
         /// </summary>
         private async Task LoadImageAsync()
         {
+            HapticFeedback.Default.Perform(HapticFeedbackType.Click);
             var results = await MediaPicker.PickPhotosAsync();
             var success = LoadImageFromPath(results[0].FullPath);
             if (!success.Result)
@@ -385,6 +386,7 @@ namespace PixelsorterApp
         /// </summary>
         private async Task SortAsync()
         {
+            HapticFeedback.Default.Perform(HapticFeedbackType.LongPress);
             if (this.imagePath is null) // Check if we have a file path
                 return;
 
@@ -450,6 +452,7 @@ namespace PixelsorterApp
         /// </summary>
         private async Task SaveAsync()
         {
+            HapticFeedback.Default.Perform(HapticFeedbackType.Click);
             var focusedImagePath = GetFocusedImagePath();
 
             if (string.IsNullOrEmpty(focusedImagePath) || !File.Exists(focusedImagePath))

--- a/PixelsorterApp/Pages/MainPage.xaml.cs
+++ b/PixelsorterApp/Pages/MainPage.xaml.cs
@@ -162,6 +162,7 @@ namespace PixelsorterApp
         /// available images.</param>
         private void ImageViewer_DisplayedImageIndexChanged(object? sender, int index)
         {
+            HapticFeedback.Default.Perform(HapticFeedbackType.Click);
             currentDisplayedImageIndex = index;
 
             if (index >= 0 && index < imageCaptions.Count)
@@ -432,6 +433,7 @@ namespace PixelsorterApp
                         SemanticProperties.SetDescription(imageViewer, $"Image preview. {caption}");
                         viewModel.IsSaveVisible = true;
                         viewModel.IsSaveEnabled = true;
+                        HapticFeedback.Default.Perform(HapticFeedbackType.LongPress);
                         SemanticScreenReader.Announce("Sorting complete. Preview updated.");
                     });
                 }

--- a/PixelsorterApp/Pages/MainPage.xaml.cs
+++ b/PixelsorterApp/Pages/MainPage.xaml.cs
@@ -69,9 +69,17 @@ namespace PixelsorterApp
         /// <param name="e">Property change event arguments.</param>
         private async void OnViewModelPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
-            if (e.PropertyName == nameof(MainPageViewModel.UseSubjectMask) && viewModel.UseSubjectMask)
+            if (e.PropertyName == nameof(MainPageViewModel.UseSubjectMask))
             {
-                await HandleSubjectMaskEnabledAsync();
+                HapticFeedback.Default.Perform(HapticFeedbackType.Click);
+                if (viewModel.UseSubjectMask)
+                {
+                    await HandleSubjectMaskEnabledAsync();
+                }
+            }
+            else if (e.PropertyName == nameof(MainPageViewModel.UseCanny))
+            {
+                HapticFeedback.Default.Perform(HapticFeedbackType.Click);
             }
             else if (e.PropertyName == nameof(MainPageViewModel.IsSaveEnabled))
             {

--- a/PixelsorterApp/Platforms/Android/MainApplication.cs
+++ b/PixelsorterApp/Platforms/Android/MainApplication.cs
@@ -3,6 +3,7 @@ using Android.Runtime;
 [assembly: UsesPermission(Android.Manifest.Permission.ReadExternalStorage, MaxSdkVersion = 32)]
 [assembly: UsesPermission(Android.Manifest.Permission.ReadMediaImages)]
 [assembly: UsesPermission(Android.Manifest.Permission.AccessNetworkState)]
+[assembly: UsesPermission(Android.Manifest.Permission.Vibrate)]
 namespace PixelsorterApp
 {
     [Application]

--- a/PixelsorterApp/ViewModels/MainPageViewModel.cs
+++ b/PixelsorterApp/ViewModels/MainPageViewModel.cs
@@ -407,11 +407,13 @@ public sealed partial class MainPageViewModel : BaseViewModel
 
     partial void OnUseSubjectMaskChanged(bool value)
     {
+        HapticFeedback.Default.Perform(HapticFeedbackType.Click);
         RefreshSortDirectionOptions();
     }
 
     partial void OnUseCannyChanged(bool value)
     {
+        HapticFeedback.Default.Perform(HapticFeedbackType.Click);
         RefreshSortDirectionOptions();
     }
 

--- a/PixelsorterApp/ViewModels/MainPageViewModel.cs
+++ b/PixelsorterApp/ViewModels/MainPageViewModel.cs
@@ -407,13 +407,11 @@ public sealed partial class MainPageViewModel : BaseViewModel
 
     partial void OnUseSubjectMaskChanged(bool value)
     {
-        HapticFeedback.Default.Perform(HapticFeedbackType.Click);
         RefreshSortDirectionOptions();
     }
 
     partial void OnUseCannyChanged(bool value)
     {
-        HapticFeedback.Default.Perform(HapticFeedbackType.Click);
         RefreshSortDirectionOptions();
     }
 


### PR DESCRIPTION
## Description
Added Haptic feedback for:
- Loading a new image
- pressing the sort button
- image is sorted
- swiping to a differante image
- pressing the save button

Haptic feedback is only active if it is enabled on the device system wide.

## Related Issue
none

## 🍎 Apple Platform Testing
<!-- IMPORTANT: The maintainer DOES NOT own an Apple device. If your changes affect iOS or MacCatalyst, you MUST test them yourself and provide proof of functionality. -->
- [x] My changes do NOT affect iOS or MacCatalyst.
- [ ] My changes affect iOS/MacCatalyst, and I have tested them thoroughly on a device/simulator. 
<!-- If you checked the second box, please attach screenshots, screen recordings, or describe your testing process below: -->


## Checklist:
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have built the solution and verified that it complies successfully.
- [x] I have tested my changes on Windows and/or Android (or they are platform-agnostic).
- [x] I have adhered to the existing UI styling (e.g., flat layouts, non-editable looking pickers, visually distinct disabled buttons).
- [x] My changes generate no new warnings.
