### PR TITLE
New navigation

### DIFF
--- a/PixelsorterApp/MaterialSymbolsFont.cs
+++ b/PixelsorterApp/MaterialSymbolsFont.cs
@@ -11,5 +11,13 @@ namespace PixelsorterApp
         public const string Check_circle = "\ue86c";
         public const string Close = "\ue5cd";
         public const string Error = "\ue000";
+
+        // Navigation icons
+        public const string Help = "\ue887";
+        public const string Collections = "\ue3b6";
+        public const string Tune = "\ue429";
+        public const string Gavel = "\ue86f";
+        public const string PrivacyTip = "\ue8e8";
+        public const string ChevronRight = "\ue5cc";
     }
 }

--- a/PixelsorterApp/MaterialSymbolsFont.cs
+++ b/PixelsorterApp/MaterialSymbolsFont.cs
@@ -13,6 +13,7 @@ namespace PixelsorterApp
         public const string Error = "\ue000";
 
         // Navigation icons
+        public const string VertMenuDots = "\ue5d4";
         public const string Help = "\ue887";
         public const string Collections = "\ue3b6";
         public const string Tune = "\ue429";

--- a/PixelsorterApp/Pages/MainPage.xaml
+++ b/PixelsorterApp/Pages/MainPage.xaml
@@ -45,6 +45,7 @@
                         Grid.Column="1"
                         Padding="0"
                         BackgroundColor="Transparent"
+                        Clicked="OnOpenHelpClicked"
                         Command="{Binding OpenHelpCommand}"
                         CornerRadius="18"
                         FontFamily="MaterialSymbolsFont"

--- a/PixelsorterApp/Pages/MainPage.xaml
+++ b/PixelsorterApp/Pages/MainPage.xaml
@@ -47,11 +47,12 @@
                         BackgroundColor="Transparent"
                         Command="{Binding OpenHelpCommand}"
                         CornerRadius="18"
+                        FontFamily="MaterialSymbolsFont"
                         FontSize="22"
                         HeightRequest="36"
                         SemanticProperties.Description="Open additional app options"
                         SemanticProperties.Hint="Opens help options including licenses and privacy policy"
-                        Text="⋮"
+                        Text="{x:Static local:MaterialSymbolsFont.VertMenuDots}"
                         TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight},
                                                     Dark={StaticResource TextSecondaryDark}}"
                         WidthRequest="36" />

--- a/PixelsorterApp/Pages/MainPage.xaml.cs
+++ b/PixelsorterApp/Pages/MainPage.xaml.cs
@@ -88,6 +88,11 @@ namespace PixelsorterApp
             }
         }
 
+        private void OnOpenHelpClicked(object sender, EventArgs e)
+        {
+            HapticFeedback.Default.Perform(HapticFeedbackType.Click);
+        }
+
         /// <summary>
         /// Animates the Share FAB appearing or disappearing with smooth fade and scale transitions.
         /// </summary>

--- a/PixelsorterApp/PixelsorterApp.csproj
+++ b/PixelsorterApp/PixelsorterApp.csproj
@@ -100,6 +100,9 @@
 	  <MauiXaml Update="Popups\ConfirmationPopup.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
+	  <MauiXaml Update="Popups\NavigationPopup.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
 	  <MauiXaml Update="Views\BeforeAfterView.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>

--- a/PixelsorterApp/Popups/NavigationPopup.xaml
+++ b/PixelsorterApp/Popups/NavigationPopup.xaml
@@ -7,8 +7,8 @@
     xmlns:local="clr-namespace:PixelsorterApp"
     x:Class="PixelsorterApp.Popups.NavigationPopup"
     BackgroundColor="{AppThemeBinding Light=#80000000, Dark=#B3000000}"
-    AppearingAnimation="{uxd:FadeInPopupAnimation Duration=350, Easing=SpringIn}"
-    DisappearingAnimation="{uxd:FadeOutPopupAnimation Duration=250, Easing=Linear}"
+    AppearingAnimation="{uxd:FadeInPopupAnimation Duration=200, Easing=CubicOut}"
+    DisappearingAnimation="{uxd:FadeOutPopupAnimation Duration=150, Easing=CubicIn}"
     CloseWhenBackgroundIsClicked="True">
 
     <Border

--- a/PixelsorterApp/Popups/NavigationPopup.xaml
+++ b/PixelsorterApp/Popups/NavigationPopup.xaml
@@ -4,32 +4,70 @@
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:uxd="clr-namespace:UXDivers.Popups.Maui;assembly=UXDivers.Popups.Maui"
+    xmlns:local="clr-namespace:PixelsorterApp"
     x:Class="PixelsorterApp.Popups.NavigationPopup"
-    BackgroundColor="{DynamicResource PopupBackdropColor}"
+    BackgroundColor="{AppThemeBinding Light=#80000000, Dark=#B3000000}"
+    AppearingAnimation="{uxd:FadeInPopupAnimation Duration=350, Easing=SpringIn}"
+    DisappearingAnimation="{uxd:FadeOutPopupAnimation Duration=250, Easing=Linear}"
     CloseWhenBackgroundIsClicked="True">
 
     <Border
         VerticalOptions="Center"
         HorizontalOptions="Center"
-        BackgroundColor="{DynamicResource BackgroundSecondaryColor}"
-        Padding="24"
-        WidthRequest="300">
+        BackgroundColor="{AppThemeBinding Light={StaticResource SurfaceLight}, Dark={StaticResource SurfaceDark}}"
+        Stroke="{AppThemeBinding Light={StaticResource DividerLight}, Dark={StaticResource DividerDark}}"
+        Padding="0"
+        WidthRequest="{OnIdiom Phone=300, Default=360}">
         <Border.StrokeShape>
             <RoundRectangle CornerRadius="16" />
         </Border.StrokeShape>
+        <Border.Shadow>
+            <Shadow Brush="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource Black}}"
+                    Opacity="{AppThemeBinding Light=0.2, Dark=0.4}"
+                    Radius="10"
+                    Offset="0,4" />
+        </Border.Shadow>
 
-        <VerticalStackLayout Spacing="16">
-            <Label
-                Text="Confirm Action"
-                Style="{DynamicResource TitleStyle}"
-                HorizontalTextAlignment="Center" />
+        <Grid RowDefinitions="Auto,Auto,*">
+            <!-- Header -->
+            <Grid Grid.Row="0" Padding="24,20,24,12" ColumnDefinitions="*,Auto">
+                <Label
+                    x:Name="TitleLabel"
+                    Grid.Column="0"
+                    FontAttributes="Bold"
+                    FontSize="18"
+                    VerticalOptions="Center"
+                    TextColor="{AppThemeBinding Light={StaticResource TextPrimaryLight}, Dark={StaticResource TextPrimaryDark}}" />
 
-            <Label
-                x:Name="MessageLabel"
-                Style="{DynamicResource SubTitleStyle}"
-                HorizontalTextAlignment="Center" />
+                <Border
+                    Grid.Column="1"
+                    StrokeThickness="0"
+                    BackgroundColor="Transparent"
+                    Padding="4"
+                    VerticalOptions="Center">
+                    <Border.StrokeShape>
+                        <RoundRectangle CornerRadius="16" />
+                    </Border.StrokeShape>
+                    <Border.GestureRecognizers>
+                        <TapGestureRecognizer Tapped="CloseButton_Clicked" />
+                    </Border.GestureRecognizers>
+                    <Label
+                        FontFamily="MaterialSymbolsFont"
+                        Text="{x:Static local:MaterialSymbolsFont.Close}"
+                        FontSize="22"
+                        TextColor="{AppThemeBinding Light={StaticResource TextSecondaryLight}, Dark={StaticResource TextSecondaryDark}}"
+                        VerticalOptions="Center"
+                        HorizontalOptions="Center" />
+                </Border>
+            </Grid>
 
-            <FlexLayout x:Name="navButtonsGrid" Wrap="Wrap" JustifyContent="Center" Direction="Row"/>
-        </VerticalStackLayout>
+            <!-- Divider -->
+            <BoxView Grid.Row="1"
+                     HeightRequest="1"
+                     Color="{AppThemeBinding Light={StaticResource DividerLight}, Dark={StaticResource DividerDark}}" />
+
+            <!-- Navigation Items -->
+            <VerticalStackLayout x:Name="navItemsContainer" Grid.Row="2" Spacing="0" Padding="0,4,0,8" />
+        </Grid>
     </Border>
 </uxd:PopupResultPage>

--- a/PixelsorterApp/Popups/NavigationPopup.xaml
+++ b/PixelsorterApp/Popups/NavigationPopup.xaml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<uxd:PopupResultPage
+    x:TypeArguments="x:String"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:uxd="clr-namespace:UXDivers.Popups.Maui;assembly=UXDivers.Popups.Maui"
+    x:Class="PixelsorterApp.Popups.NavigationPopup"
+    BackgroundColor="{DynamicResource PopupBackdropColor}"
+    CloseWhenBackgroundIsClicked="True">
+
+    <Border
+        VerticalOptions="Center"
+        HorizontalOptions="Center"
+        BackgroundColor="{DynamicResource BackgroundSecondaryColor}"
+        Padding="24"
+        WidthRequest="300">
+        <Border.StrokeShape>
+            <RoundRectangle CornerRadius="16" />
+        </Border.StrokeShape>
+
+        <VerticalStackLayout Spacing="16">
+            <Label
+                Text="Confirm Action"
+                Style="{DynamicResource TitleStyle}"
+                HorizontalTextAlignment="Center" />
+
+            <Label
+                x:Name="MessageLabel"
+                Style="{DynamicResource SubTitleStyle}"
+                HorizontalTextAlignment="Center" />
+
+            <FlexLayout x:Name="navButtonsGrid" Wrap="Wrap" JustifyContent="Center" Direction="Row"/>
+        </VerticalStackLayout>
+    </Border>
+</uxd:PopupResultPage>

--- a/PixelsorterApp/Popups/NavigationPopup.xaml.cs
+++ b/PixelsorterApp/Popups/NavigationPopup.xaml.cs
@@ -1,0 +1,47 @@
+using System.Windows.Input;
+using UXDivers.Popups.Maui;
+using UXDivers.Popups.Services;
+
+using System.Collections.Generic;
+
+namespace PixelsorterApp.Popups;
+
+public partial class NavigationPopup : PopupResultPage<String>
+{
+    private ICommand SetResultCommand;
+    public NavigationPopup()
+    {
+        InitializeComponent();
+        SetResultCommand = new Command(async result => 
+        { 
+            SetResult(result?.ToString()); 
+            await IPopupService.Current.PopAsync(this);
+        });
+    }
+
+
+    public override void OnNavigatedTo(IReadOnlyDictionary<string, object?> parameters)
+    {
+        base.OnNavigatedTo(parameters);
+        
+        navButtonsGrid.Children.Clear();
+
+        if (parameters.TryGetValue("Message", out var message)) {
+            MessageLabel.Text = message?.ToString();
+        }
+
+        if (parameters.TryGetValue("Options", out var options) && options is IEnumerable<string> buttonOptions) {
+            foreach (var option in buttonOptions) {
+                navButtonsGrid.Add(
+                    new Button()
+                    {
+                        Text = option,
+                        Command = SetResultCommand,
+                        CommandParameter = option,
+                        Margin = new Thickness(6)
+                    }
+                );
+            }
+        }
+    }
+}

--- a/PixelsorterApp/Popups/NavigationPopup.xaml.cs
+++ b/PixelsorterApp/Popups/NavigationPopup.xaml.cs
@@ -9,12 +9,13 @@ namespace PixelsorterApp.Popups;
 public partial class NavigationPopup : PopupResultPage<String>
 {
     private ICommand SetResultCommand;
+
     public NavigationPopup()
     {
         InitializeComponent();
-        SetResultCommand = new Command(async result => 
-        { 
-            SetResult(result?.ToString()); 
+        SetResultCommand = new Command(async result =>
+        {
+            SetResult(result?.ToString());
             await IPopupService.Current.PopAsync(this);
         });
     }
@@ -23,25 +24,133 @@ public partial class NavigationPopup : PopupResultPage<String>
     public override void OnNavigatedTo(IReadOnlyDictionary<string, object?> parameters)
     {
         base.OnNavigatedTo(parameters);
-        
-        navButtonsGrid.Children.Clear();
 
-        if (parameters.TryGetValue("Message", out var message)) {
-            MessageLabel.Text = message?.ToString();
+        navItemsContainer.Children.Clear();
+
+        if (parameters.TryGetValue("Title", out var title))
+        {
+            TitleLabel.Text = title?.ToString() ?? "Navigation";
         }
 
-        if (parameters.TryGetValue("Options", out var options) && options is IEnumerable<string> buttonOptions) {
-            foreach (var option in buttonOptions) {
-                navButtonsGrid.Add(
-                    new Button()
-                    {
-                        Text = option,
-                        Command = SetResultCommand,
-                        CommandParameter = option,
-                        Margin = new Thickness(6)
-                    }
-                );
+        if (parameters.TryGetValue("Options", out var options) && options is IEnumerable<(string Label, string Icon)> navOptions)
+        {
+            var optionsList = new List<(string Label, string Icon)>(navOptions);
+            for (int i = 0; i < optionsList.Count; i++)
+            {
+                var isLast = i == optionsList.Count - 1;
+                navItemsContainer.Add(CreateNavItem(optionsList[i].Label, optionsList[i].Icon, isLast));
             }
         }
+    }
+
+    private View CreateNavItem(string label, string icon, bool isLast)
+    {
+        var container = new VerticalStackLayout { Spacing = 0 };
+
+        // The tappable row
+        var row = new Grid
+        {
+            ColumnDefinitions = new ColumnDefinitionCollection
+            {
+                new ColumnDefinition(new GridLength(40)),   // Icon column
+                new ColumnDefinition(GridLength.Star),       // Text column
+                new ColumnDefinition(new GridLength(32)),   // Chevron column
+            },
+            Padding = new Thickness(20, 14),
+            BackgroundColor = Colors.Transparent,
+        };
+
+        // Leading icon
+        var iconLabel = new Label
+        {
+            FontFamily = "MaterialSymbolsFont",
+            Text = icon,
+            FontSize = 22,
+            VerticalOptions = LayoutOptions.Center,
+            HorizontalOptions = LayoutOptions.Center,
+        };
+        iconLabel.SetAppThemeColor(Label.TextColorProperty,
+            (Color)Application.Current!.Resources["Primary"],
+            (Color)Application.Current!.Resources["PrimaryDark"]);
+        Grid.SetColumn(iconLabel, 0);
+
+        // Text label
+        var textLabel = new Label
+        {
+            Text = label,
+            FontSize = 15,
+            FontFamily = "DMSansRegular",
+            VerticalOptions = LayoutOptions.Center,
+        };
+        textLabel.SetAppThemeColor(Label.TextColorProperty,
+            (Color)Application.Current!.Resources["TextPrimaryLight"],
+            (Color)Application.Current!.Resources["TextPrimaryDark"]);
+        Grid.SetColumn(textLabel, 1);
+
+        // Trailing chevron
+        var chevron = new Label
+        {
+            FontFamily = "MaterialSymbolsFont",
+            Text = MaterialSymbolsFont.ChevronRight,
+            FontSize = 20,
+            VerticalOptions = LayoutOptions.Center,
+            HorizontalOptions = LayoutOptions.Center,
+        };
+        chevron.SetAppThemeColor(Label.TextColorProperty,
+            (Color)Application.Current!.Resources["TextSecondaryLight"],
+            (Color)Application.Current!.Resources["TextSecondaryDark"]);
+        Grid.SetColumn(chevron, 2);
+
+        row.Add(iconLabel);
+        row.Add(textLabel);
+        row.Add(chevron);
+
+        // Tap gesture
+        var tapGesture = new TapGestureRecognizer
+        {
+            Command = SetResultCommand,
+            CommandParameter = label,
+        };
+        row.GestureRecognizers.Add(tapGesture);
+
+        // Pointer-over visual feedback via PointerGestureRecognizer
+        var pointerGesture = new PointerGestureRecognizer();
+        pointerGesture.PointerEntered += (s, e) =>
+        {
+            if (Application.Current!.RequestedTheme == AppTheme.Dark)
+                row.BackgroundColor = Color.FromArgb("#15FFFFFF");
+            else
+                row.BackgroundColor = Color.FromArgb("#0A000000");
+        };
+        pointerGesture.PointerExited += (s, e) =>
+        {
+            row.BackgroundColor = Colors.Transparent;
+        };
+        row.GestureRecognizers.Add(pointerGesture);
+
+        container.Add(row);
+
+        // Separator line (except after the last item)
+        if (!isLast)
+        {
+            var separator = new BoxView
+            {
+                HeightRequest = 1,
+                Margin = new Thickness(60, 0, 20, 0), // Indent to align with text, not icon
+            };
+            separator.SetAppThemeColor(BoxView.ColorProperty,
+                (Color)Application.Current!.Resources["DividerLight"],
+                (Color)Application.Current!.Resources["DividerDark"]);
+            separator.Opacity = 0.6;
+
+            container.Add(separator);
+        }
+
+        return container;
+    }
+
+    private async void CloseButton_Clicked(object? sender, EventArgs e)
+    {
+        await IPopupService.Current.PopAsync(this);
     }
 }

--- a/PixelsorterApp/Popups/NavigationPopup.xaml.cs
+++ b/PixelsorterApp/Popups/NavigationPopup.xaml.cs
@@ -15,6 +15,7 @@ public partial class NavigationPopup : PopupResultPage<String>
         InitializeComponent();
         SetResultCommand = new Command(async result =>
         {
+            HapticFeedback.Default.Perform(HapticFeedbackType.Click);
             SetResult(result?.ToString());
             await IPopupService.Current.PopAsync(this);
         });

--- a/PixelsorterApp/Popups/NavigationPopup.xaml.cs
+++ b/PixelsorterApp/Popups/NavigationPopup.xaml.cs
@@ -10,13 +10,20 @@ public partial class NavigationPopup : PopupResultPage<String>
 {
     private ICommand SetResultCommand;
 
+    public event EventHandler<string>? OptionSelected;
+
     public NavigationPopup()
     {
         InitializeComponent();
         SetResultCommand = new Command(async result =>
         {
             HapticFeedback.Default.Perform(HapticFeedbackType.Click);
-            SetResult(result?.ToString());
+            var selection = result?.ToString();
+            SetResult(selection);
+            if (!string.IsNullOrEmpty(selection))
+            {
+                OptionSelected?.Invoke(this, selection);
+            }
             await IPopupService.Current.PopAsync(this);
         });
     }

--- a/PixelsorterApp/Services/HelpNavigationService.cs
+++ b/PixelsorterApp/Services/HelpNavigationService.cs
@@ -24,6 +24,11 @@ public sealed class HelpNavigationService : IHelpNavigationService
         }
 
         var popup = new NavigationPopup();
+        popup.OptionSelected += (sender, selection) =>
+        {
+            _ = NavigateToSelectionAsync(currentPage, selection);
+        };
+
         var parameters = new Dictionary<string, object?>
         {
             { "Title", "Help & Info" },
@@ -36,10 +41,11 @@ public sealed class HelpNavigationService : IHelpNavigationService
             } }
         };
 
-        var selection = await IPopupService.Current.PushAsync(popup, parameters);
+        await IPopupService.Current.PushAsync(popup, parameters);
+    }
 
-        Debug.WriteLine("Nav choise: " + selection);
-
+    private async Task NavigateToSelectionAsync(Page currentPage, string selection)
+    {
         switch (selection)
         {
             case "Help Page":

--- a/PixelsorterApp/Services/HelpNavigationService.cs
+++ b/PixelsorterApp/Services/HelpNavigationService.cs
@@ -1,4 +1,7 @@
 using PixelsorterApp.Pages;
+using PixelsorterApp.Popups;
+using System.Diagnostics;
+using UXDivers.Popups.Services;
 
 namespace PixelsorterApp.Services;
 
@@ -20,15 +23,23 @@ public sealed class HelpNavigationService : IHelpNavigationService
             return;
         }
 
-        var selection = await currentPage.DisplayActionSheetAsync(
-            "Help & Info",
-            "Cancel",
-            null,
-            "Help Page",
-            "Example Gallery",
-            "Presets page",
-            "Open Source Licenses",
-            "Privacy Policy");
+        var popup = new NavigationPopup();
+        var parameters = new Dictionary<string, object?>
+        {
+            { "Message", "Help & Info" },
+            { "Options", new List<string> { 
+                "Help Page", 
+                "Example Gallery", 
+                "Presets page", 
+                "Open Source Licenses", 
+                "Privacy Policy", 
+                "Cancel" 
+            } }
+        };
+
+        var selection = await IPopupService.Current.PushAsync(popup, parameters);
+
+        Debug.WriteLine("Nav choise: " + selection);
 
         switch (selection)
         {

--- a/PixelsorterApp/Services/HelpNavigationService.cs
+++ b/PixelsorterApp/Services/HelpNavigationService.cs
@@ -26,14 +26,13 @@ public sealed class HelpNavigationService : IHelpNavigationService
         var popup = new NavigationPopup();
         var parameters = new Dictionary<string, object?>
         {
-            { "Message", "Help & Info" },
-            { "Options", new List<string> { 
-                "Help Page", 
-                "Example Gallery", 
-                "Presets page", 
-                "Open Source Licenses", 
-                "Privacy Policy", 
-                "Cancel" 
+            { "Title", "Help & Info" },
+            { "Options", new List<(string Label, string Icon)> { 
+                ("Help Page", MaterialSymbolsFont.Help), 
+                ("Example Gallery", MaterialSymbolsFont.Collections), 
+                ("Presets page", MaterialSymbolsFont.Tune), 
+                ("Open Source Licenses", MaterialSymbolsFont.Gavel), 
+                ("Privacy Policy", MaterialSymbolsFont.PrivacyTip), 
             } }
         };
 


### PR DESCRIPTION
## Description
###  `NavigationPopup` UI & Architecture
* **Custom Modal**: Introduced `NavigationPopup.xaml` / `.cs` built with `UXDivers.Popups.PopupPage`, featuring a structured header with title, close button, subtle outer shadow, and dynamic item list generation.
* **Service Integration**: Updated `HelpNavigationService.cs` to pass `(Label, Icon)` tuples and display `NavigationPopup` instead of standard action sheets.

### Animations & Haptic Feedback
* **Animations**: Added entry/exit transitions with faster cubic easing for a quick and responsive feel.
* **Haptics**: Added haptic feedback on opening the help menu from `MainPage.xaml.cs` as well as when selecting navigation choices inside the popup.

## Related Issue
<!-- If fixing a bug or resolving a feature request, link to the issue here (e.g., "Fixes #123") -->

## 🍎 Apple Platform Testing
<!-- IMPORTANT: The maintainer DOES NOT own an Apple device. If your changes affect iOS or MacCatalyst, you MUST test them yourself and provide proof of functionality. -->
- [x] My changes do NOT affect iOS or MacCatalyst.
- [ ] My changes affect iOS/MacCatalyst, and I have tested them thoroughly on a device/simulator. 
<!-- If you checked the second box, please attach screenshots, screen recordings, or describe your testing process below: -->


## Checklist:
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md).
- [x] I have built the solution and verified that it complies successfully.
- [x] I have tested my changes on Windows and/or Android (or they are platform-agnostic).
- [x] I have adhered to the existing UI styling (e.g., flat layouts, non-editable looking pickers, visually distinct disabled buttons).
- [x] My changes generate no new warnings.
